### PR TITLE
Correctly Destroy PR Environment

### DIFF
--- a/.github/workflows/terraform-ci-destroy.yml
+++ b/.github/workflows/terraform-ci-destroy.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Terraform Init
-        run: terraform init -backend-config="key=pr_${{ github.event.number }}.tfstate"
+        run: terraform init -backend-config="key=rs_sftp_pr_${{ github.event.number }}.tfstate"
 
       - name: Terraform Destroy
         run: terraform destroy -auto-approve -input=false -var="pr_number=${{ github.event.number }}"

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ reportstream-sftp-ingestion
 
 # IDE files
 .idea/
+
+# Ignore terraform state (as it is persisted via Azure Storage)
+terraform.tfstate*
+.terraform*


### PR DESCRIPTION
# Correctly Destroy PR Environment

We weren't correctly referencing the remote state when destroying the PR environment.  We now reference the correct one.
Also, we ignore terraform state in git.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1075
