### PR TITLE
Adding docker compose for app and azurite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ reportstream-sftp-ingestion
 # Ignore terraform state (as it is persisted via Azure Storage)
 terraform.tfstate*
 .terraform*
+
+# Local blob storage data
+/localdata

--- a/README.md
+++ b/README.md
@@ -54,12 +54,9 @@ pre-commit install
 ```
 
 ### Running locally
-For the Azure blob storage modify and run the below command to spin up Azurite which will run blob storage locally
-
-
-```shell
-azurite --silent --location ~/AzuritelocationOnYourMachine --debug ~/location/for/logs/debug.log
-```
+Run `docker-compose`, which will spin up both an Azurite container and the app. By default, this leaves the ReportStream
+URL prefix environment variable empty, and we'll use a mock response rather than calling ReportStream. Uncomment
+the `REPORT_STREAM_URL_PREFIX` in [docker-compose.yml](docker-compose.yml) to call locally-running ReportStream instead.
 
 ### Testing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.7"
+services:
+  rs-sftp:
+    build: .
+    environment:
+      AZURE_BLOB_CONNECTION_STRING: DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://sftp-Azurite:10000/devstoreaccount1;
+      ENV: local
+      # Uncomment the line below to call local report stream. Otherwise we'll use a mock response
+      #REPORT_STREAM_URL_PREFIX: http://localhost:7071
+    ports:
+      - "9090:9090" # default api endpoint port
+    platform: linux/amd64
+    depends_on:
+      - sftp-Azurite
+    networks:
+      - sftp
+
+  sftp-Azurite:
+    image: mcr.microsoft.com/azure-storage/azurite
+    # uncomment the line below to skip x-ms-version checks
+    # command: azurite --skipApiVersionCheck --blobHost 0.0.0.0 --queueHost 0.0.0.0
+    volumes:
+      # map to Azurite data objects to the build directory
+      - ./localdata/azurite:/data
+    ports:
+      - "11000:10000"
+      - "11001:10001"
+      - "11002:10002"
+    networks:
+      - sftp
+
+
+networks:
+  sftp:

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -28,13 +28,21 @@ func main() {
 	}
 
 	reportStreamBaseUrl := os.Getenv("REPORT_STREAM_URL_PREFIX")
-	apiHandler := report_stream.ApiHandler{BaseUrl: reportStreamBaseUrl}
-	reportId, err := apiHandler.SendReport(content)
-	if err != nil {
-		slog.Error("Failed to send the file to ReportStream", slog.Any("error", err))
-		os.Exit(1)
+
+	if reportStreamBaseUrl == "" {
+		// Do something with mock response
+
+		slog.Info("Mock message sent to Mock RS.")
+	} else {
+		apiHandler := report_stream.ApiHandler{BaseUrl: reportStreamBaseUrl}
+		reportId, err := apiHandler.SendReport(content)
+
+		if err != nil {
+			slog.Error("Failed to send the file to ReportStream", slog.Any("error", err))
+			os.Exit(1)
+		}
+		slog.Info("File sent to ReportStream", slog.String("reportId", reportId))
 	}
-	slog.Info("File sent to ReportStream", slog.String("reportId", reportId))
 
 	for {
 		t := time.Now()


### PR DESCRIPTION
# Adding docker compose for app and azurite
This adds docker compose with appropriate env variables for the app and a local azurite container, and begins to stub out a mock reportstream interaction

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1075

## Checklist

- [x] I have added logging where useful (with appropriate log level)
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
