### PR TITLE
Use an interface for Azure blob storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       # map to Azurite data objects to the build directory
       - ./localdata/reportstream:/localdata
     ports:
-      - "9090:9090" # default api endpoint port
+      - "9999:9090" # default api endpoint port
     platform: linux/amd64
     depends_on:
       sftp-Azurite:
@@ -29,9 +29,9 @@ services:
       # map to Azurite data objects to the build directory
       - ./localdata/azurite:/data
     ports:
-      - "11000:10000"
-      - "11001:10001"
-      - "11002:10002"
+      - "12000:10000"
+      - "12001:10001"
+      - "12002:10002"
     networks:
       - sftp
 

--- a/src/azure/storage.go
+++ b/src/azure/storage.go
@@ -6,22 +6,22 @@ import (
 	"io"
 )
 
-type BlobHandler struct {
+type StorageHandler struct {
 	blobClient *azblob.Client
 }
 
-func NewBlobHandler(conn string) (BlobHandler, error) {
+func NewBlobHandler(conn string) (StorageHandler, error) {
 	blobClient, err := azblob.NewClientFromConnectionString(conn, nil)
 	if err != nil {
-		return BlobHandler{}, err
+		return StorageHandler{}, err
 	}
 
-	return BlobHandler{blobClient: blobClient}, nil
+	return StorageHandler{blobClient: blobClient}, nil
 }
 
 // TODO - container should eventually be managed by Terraform
 
-func (receiver BlobHandler) FetchFile(blobPath string) ([]byte, error) {
+func (receiver StorageHandler) FetchFile(blobPath string) ([]byte, error) {
 	// TODO - read containerName from env vars
 	containerName := "sftp"
 

--- a/src/cmd/blob.go
+++ b/src/cmd/blob.go
@@ -1,0 +1,12 @@
+package main
+
+type BlobHandler interface {
+	FetchFile(blobPath string) ([]byte, error)
+}
+
+/**
+Future things to implement:
+put file
+move file
+delete file
+*/

--- a/src/cmd/blob.go
+++ b/src/cmd/blob.go
@@ -1,5 +1,7 @@
 package main
 
+// The BlobHandler interface is about interacting with file data,
+// e.g. in Azure Blob Storage or a local filesystem
 type BlobHandler interface {
 	FetchFile(blobPath string) ([]byte, error)
 }

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -65,10 +65,6 @@ func setupLogging() {
 	}
 }
 
-type BlobHandler interface {
-	FetchFile(blobPath string) ([]byte, error)
-}
-
 func readAzureFile(blobHandler BlobHandler, filePath string) ([]byte, error) {
 	content, err := blobHandler.FetchFile(filePath)
 	if err != nil {

--- a/src/cmd/sender.go
+++ b/src/cmd/sender.go
@@ -1,5 +1,7 @@
 package main
 
+// The MessageSender interface is about delivering data to external services.
+// Currently, we send messages to ReportStream or to a mock service for testing.
 type MessageSender interface {
 	SendMessage(message []byte) (string, error)
 }


### PR DESCRIPTION
# Use an interface for Azure blob storage

- Use an interface for Azure blob storage
- Deconflict some ports that ReportStream is now using
- Do a little renaming for clarity

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1075

## Checklist
- [x] I have added GoDocs where required

**Note**: You may remove items that are not applicable
