### PR TITLE
Turning on SFTP for storage account

### DIFF
--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -6,6 +6,8 @@ resource "azurerm_storage_account" "storage" {
   account_replication_type        = "GRS"
   account_kind                    = "StorageV2"
   allow_nested_items_to_be_public = false
+  is_hns_enabled                  = true
+  sftp_enabled                    = true
 }
 
 resource "azurerm_storage_container" "sftp_container" {


### PR DESCRIPTION
# SFTP For Azure Storage
In order to enable SFTP support for our partners we need to set 2 flags on our Storage Account to allow us to generate the credentials that we will distribute to our partners. 

## Issue
[Link to issue](https://github.com/CDCgov/trusted-intermediary/issues/1075)


