### PR TITLE
1075: Rename Sonar Token Secret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         uses: sonarsource/sonarcloud-github-action@v2.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SFTP_INGESTION_SONAR_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
           projectBaseDir: src
           args: >


### PR DESCRIPTION
# Rename Sonar Token Secret

Renamed our Sonar token secret.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1075