### PR TITLE
1075: Inherit Secrets for Sonar Scanning

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,6 +12,7 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    secrets: inherit  # pragma: allowlist secret
 
   terraform-deploy:
     name: Staging Infrastructure Deploy


### PR DESCRIPTION
# Inherit Secrets for Sonar Scanning

When running against the `main` branch, the `CI/CD` workflow is the top level workflow and defers to the `CI` workflow.  Because of this, the `CI` workflow doesn't get automatic access to secrets.  This PR gives access by allowing the workflow to inherit the secrets.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1075
