### PR TITLE
1075: Refining Sonar Code Coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           args: >
             -Dsonar.projectKey=CDCgov_reportstream-sftp-ingestion
             -Dsonar.organization=cdcgov
+            -Dsonar.sources=.
+            -Dsonar.exclusions=**/*_test.go
             -Dsonar.tests=.
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.go.coverage.reportPaths=coverage.out

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           args: >
             -Dsonar.projectKey=CDCgov_reportstream-sftp-ingestion
             -Dsonar.organization=cdcgov
+            -Dsonar.tests=.
+            -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.go.coverage.reportPaths=coverage.out
 
   securityScanAnalyze:


### PR DESCRIPTION
# Refining Sonar Code Coverage

Trying to reduce the scope that SonarCloud considers for code coverage.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1075