### PR TITLE
1076: Allow Deployment in CDC Again

### DIFF
--- a/operations/template/event.tf
+++ b/operations/template/event.tf
@@ -53,6 +53,4 @@ resource "azurerm_role_assignment" "allow_event_read_write" {
   scope                = azurerm_storage_account.storage.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_eventgrid_system_topic.topic.identity.0.principal_id
-
-  depends_on = [azurerm_eventgrid_system_topic.topic]
 }

--- a/operations/template/event.tf
+++ b/operations/template/event.tf
@@ -49,20 +49,8 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "topic_sub" {
   depends_on = [azurerm_role_assignment.allow_event_read_write]
 }
 
-resource "azurerm_role_definition" "event_grid_role" {
-  name        = "event-grid-role-${var.environment}"
-  scope       = data.azurerm_resource_group.group.id
-  description = "Role to allow eventgrid to trigger on blob create and send queue messages"
-
-  permissions {
-    actions      = []
-    not_actions  = []
-    data_actions = ["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write"]
-  }
-}
-
 resource "azurerm_role_assignment" "allow_event_read_write" {
-  scope              = azurerm_storage_account.storage.id
-  role_definition_id = azurerm_role_definition.event_grid_role.role_definition_resource_id
-  principal_id       = azurerm_eventgrid_system_topic.topic.identity.0.principal_id
+  scope                = azurerm_storage_account.storage.id
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azurerm_eventgrid_system_topic.topic.identity.0.principal_id
 }

--- a/operations/template/event.tf
+++ b/operations/template/event.tf
@@ -45,6 +45,8 @@ resource "azurerm_eventgrid_system_topic_event_subscription" "topic_sub" {
     storage_account_id          = azurerm_storage_account.storage.id
     storage_blob_container_name = azurerm_storage_container.sftp_container_dead_letter.name
   }
+
+  depends_on = [azurerm_role_assignment.allow_event_read_write]
 }
 
 resource "azurerm_role_definition" "event_grid_role" {

--- a/operations/template/event.tf
+++ b/operations/template/event.tf
@@ -53,4 +53,6 @@ resource "azurerm_role_assignment" "allow_event_read_write" {
   scope                = azurerm_storage_account.storage.id
   role_definition_name = "Storage Blob Data Contributor"
   principal_id         = azurerm_eventgrid_system_topic.topic.identity.0.principal_id
+
+  depends_on = [azurerm_eventgrid_system_topic.topic]
 }

--- a/operations/template/logs.tf
+++ b/operations/template/logs.tf
@@ -37,4 +37,7 @@ resource "azurerm_monitor_diagnostic_setting" "app_to_logs" {
   enabled_log {
     category = "AppServiceHTTPLogs"
   }
+  enabled_log {
+    category = "AppServicePlatformLogs"
+  }
 }

--- a/operations/template/logs.tf
+++ b/operations/template/logs.tf
@@ -37,7 +37,4 @@ resource "azurerm_monitor_diagnostic_setting" "app_to_logs" {
   enabled_log {
     category = "AppServiceHTTPLogs"
   }
-  enabled_log {
-    category = "AppServicePlatformLogs"
-  }
 }


### PR DESCRIPTION
# Allow Deployment in CDC Again

Our GitHub deployer in the CDC domain has different permissions than in the Flexion domain.  The CDC permissions only allow the deployer to assign certain, very specific roles.  Because we were creating a new role, it wasn't one of the specific roles we were pre-allowed to assigned.  So... we need to use a pre-created role which sadly is slightly less secure because it allows more things than we need.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1076
