### PR TITLE
Adding method to exclude code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ unitTests:
 	cd ./src/ && go test ./... -cover -coverprofile=coverage.out
 
 unitTestsWithCoverageThreshold: unitTests
+	./codeCoverageFilter.sh
 	./codeCoverageThresholdCheck.sh
 
 vet:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ the `REPORT_STREAM_URL_PREFIX` in [docker-compose.yml](docker-compose.yml) to ca
 make unitTests
 ```
 
+To update which files are excluded from the test coverage report update the `codeCoverageFilter.sh`script.
+
 #### Manual local testing
 In the cloud, EventGrid monitors the blob storage container and sends file creation events to our queue for the app to read.
 In the local Azurite tool, there are no events to connect the blob storage container to the queue.

--- a/codeCoverageFilter.sh
+++ b/codeCoverageFilter.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+pushd ./src/ || exit
+
+EXCLUDE_FILES=(
+  github.com/CDCgov/reportstream-sftp-ingestion/cmd/main.go
+  github.com/CDCgov/reportstream-sftp-ingestion/storage/azure.go
+)
+
+for exclusion in "${EXCLUDE_FILES[@]}"
+do
+  sed -i '' "/${exclusion//\//\\/}/d" ./coverage.out
+done

--- a/codeCoverageFilter.sh
+++ b/codeCoverageFilter.sh
@@ -4,11 +4,16 @@ set -e
 pushd ./src/ || exit
 
 EXCLUDE_FILES=(
-  github.com\/CDCgov\/reportstream-sftp-ingestion\/cmd\/main.go
-  github.com\/CDCgov\/reportstream-sftp-ingestion\/storage\/azure.go
+  github.com/CDCgov/reportstream-sftp-ingestion/cmd/main.go
+  github.com/CDCgov/reportstream-sftp-ingestion/storage/azure.go
 )
 
 for exclusion in "${EXCLUDE_FILES[@]}"
 do
-  sed -i '' "/${exclusion//\//\\/}/d" ./coverage.out
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    sed -i '' "/${exclusion//\//\\/}/d" ./coverage.out
+  else
+    sed -i "/${exclusion//\//\\/}/d" ./coverage.out
+  fi
+
 done

--- a/codeCoverageFilter.sh
+++ b/codeCoverageFilter.sh
@@ -4,8 +4,8 @@ set -e
 pushd ./src/ || exit
 
 EXCLUDE_FILES=(
-  github.com/CDCgov/reportstream-sftp-ingestion/cmd/main.go
-  github.com/CDCgov/reportstream-sftp-ingestion/storage/azure.go
+  github.com\/CDCgov\/reportstream-sftp-ingestion\/cmd\/main.go
+  github.com\/CDCgov\/reportstream-sftp-ingestion\/storage\/azure.go
 )
 
 for exclusion in "${EXCLUDE_FILES[@]}"

--- a/codeCoverageThresholdCheck.sh
+++ b/codeCoverageThresholdCheck.sh
@@ -3,7 +3,7 @@ set -e
 
 pushd ./src/ || exit
 
-THRESHOLD=30
+THRESHOLD=40
 COVERAGE=$(go tool cover -func ./coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+')
 
 echo "Code coverage is $COVERAGE%, and the threshold is $THRESHOLD%"


### PR DESCRIPTION
We have certain files we don't want to include in our test coverage.  This PR gives developers a way to exclude files from being included in the test coverage report.

## Issue
[SFTP Service](https://app.zenhub.com/workspaces/cdc-ti-633de70d939f6c00155f3722/issues/gh/cdcgov/trusted-intermediary/1076)

## Checklist
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
