### PR TITLE
1077: Remove Context from the `QueueHandler` Struct

### DIFF
--- a/src/orchestration/queue.go
+++ b/src/orchestration/queue.go
@@ -17,7 +17,6 @@ import (
 type QueueHandler struct {
 	queueClient           QueueClient
 	deadLetterQueueClient QueueClient
-	ctx                   context.Context
 	usecase               usecases.ReadAndSend
 }
 
@@ -49,7 +48,7 @@ func NewQueueHandler() (QueueHandler, error) {
 		return QueueHandler{}, err
 	}
 
-	return QueueHandler{queueClient: client, deadLetterQueueClient: dlqClient, ctx: context.Background(), usecase: &usecase}, nil
+	return QueueHandler{queueClient: client, deadLetterQueueClient: dlqClient, usecase: &usecase}, nil
 }
 
 func getUrlFromMessage(messageText string) (string, error) {
@@ -90,7 +89,7 @@ func (receiver QueueHandler) deleteMessage(message azqueue.DequeuedMessage) erro
 	messageId := *message.MessageID
 	popReceipt := *message.PopReceipt
 
-	deleteResponse, err := receiver.queueClient.DeleteMessage(receiver.ctx, messageId, popReceipt, nil)
+	deleteResponse, err := receiver.queueClient.DeleteMessage(context.Background(), messageId, popReceipt, nil)
 	if err != nil {
 		slog.Error("Unable to delete message", slog.Any("error", err))
 		return err
@@ -191,7 +190,7 @@ func (receiver QueueHandler) receiveQueue() error {
 
 	slog.Info("Trying to dequeue")
 
-	messageResponse, err := receiver.queueClient.DequeueMessage(receiver.ctx, nil)
+	messageResponse, err := receiver.queueClient.DequeueMessage(context.Background(), nil)
 	if err != nil {
 		slog.Error("Unable to dequeue messages", err)
 		return err

--- a/src/orchestration/queue_test.go
+++ b/src/orchestration/queue_test.go
@@ -73,7 +73,7 @@ func Test_getUrlFromMessage_returnsErrorWhenMessageCannotUnmarshal(t *testing.T)
 func Test_deleteMessage_returnNilWhenMessageCanBeDeleted(t *testing.T) {
 	mockQueueClient := MockQueueClient{}
 	mockQueueClient.On("DeleteMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(azqueue.DeleteMessageResponse{}, nil)
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background()}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient}
 
 	message := createGoodMessage()
 
@@ -85,7 +85,7 @@ func Test_deleteMessage_returnNilWhenMessageCanBeDeleted(t *testing.T) {
 func Test_deleteMessage_returnErrorWhenMessageCannotBeDeleted(t *testing.T) {
 	mockQueueClient := MockQueueClient{}
 	mockQueueClient.On("DeleteMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(azqueue.DeleteMessageResponse{}, errors.New("unable to delete message"))
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background()}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient}
 
 	message := createGoodMessage()
 
@@ -101,7 +101,7 @@ func Test_handleMessage_returnNilWhenMessageHandledSuccessfully(t *testing.T) {
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 
 	mockReadAndSendUsecase.On("ReadAndSend", mock.AnythingOfType("string")).Return(nil)
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createGoodMessage()
 
@@ -119,7 +119,7 @@ func Test_handleMessage_returnErrorWhenFailedToGetFileUrl(t *testing.T) {
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 
 	mockReadAndSendUsecase.On("ReadAndSend", mock.AnythingOfType("string")).Return(nil)
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createBadMessage()
 
@@ -137,7 +137,7 @@ func Test_handleMessage_returnErrorWhenFailureWithDeleteMessage(t *testing.T) {
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 
 	mockReadAndSendUsecase.On("ReadAndSend", mock.AnythingOfType("string")).Return(nil)
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createGoodMessage()
 
@@ -154,7 +154,7 @@ func Test_handleMessage_returnErrorWhenFailureWithReadAndSend(t *testing.T) {
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 
 	mockReadAndSendUsecase.On("ReadAndSend", mock.AnythingOfType("string")).Return(errors.New("failed to read and send"))
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createGoodMessage()
 
@@ -173,7 +173,7 @@ func Test_handleMessage_returnErrorWhenOverDequeueThreshold(t *testing.T) {
 
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createMessageOverDequeueThreshold()
 
@@ -198,7 +198,7 @@ func Test_ReceiveQueue_HappyPath(t *testing.T) {
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 	mockReadAndSendUsecase.On("ReadAndSend", mock.AnythingOfType("string")).Return(nil)
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 	err := queueHandler.receiveQueue()
 
 	mockQueueClient.AssertCalled(t, "DequeueMessage", mock.Anything, mock.Anything)
@@ -212,7 +212,7 @@ func Test_ReceiveQueue_UnableToDequeueMessage(t *testing.T) {
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 	mockReadAndSendUsecase.On("ReadAndSend", mock.AnythingOfType("string")).Return(nil)
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 	err := queueHandler.receiveQueue()
 
 	assert.Error(t, err)
@@ -237,7 +237,7 @@ func Test_ReceiveQueue_logsErrorWhenUnableToHandleMessage(t *testing.T) {
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 	mockReadAndSendUsecase.On("ReadAndSend", mock.AnythingOfType("string")).Return(nil)
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 	err := queueHandler.receiveQueue()
 
 	mockQueueClient.AssertCalled(t, "DequeueMessage", mock.Anything, mock.Anything)
@@ -266,7 +266,7 @@ func Test_ReceiveQueue_handlesMultipleMessages(t *testing.T) {
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
 	mockReadAndSendUsecase.On("ReadAndSend", mock.AnythingOfType("string")).Return(nil)
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 	err := queueHandler.receiveQueue()
 
 	assert.NoError(t, err)
@@ -290,7 +290,7 @@ func Test_overDeliveryThreshold_deliveryCountParsedAndUnderDequeueThreshold(t *t
 
 	mockQueueClient := MockQueueClient{}
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createGoodMessage()
 
@@ -319,7 +319,7 @@ func Test_overDeliveryThreshold_deliveryCountParsedAndOverDequeueThreshold(t *te
 	mockDeadLetterQueueClient.On("EnqueueMessage", mock.Anything, mock.Anything, mock.Anything).Return(azqueue.EnqueueMessagesResponse{}, nil)
 
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createMessageOverDequeueThreshold()
 	overThreshold := queueHandler.overDeliveryThreshold(message)
@@ -343,7 +343,7 @@ func Test_overDeliveryThreshold_deliveryCountCannotParseAndUnderDequeueThreshold
 
 	mockQueueClient := MockQueueClient{}
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createGoodMessage()
 
@@ -371,7 +371,7 @@ func Test_overDeliveryThreshold_deliveryCountCannotParseAndOverDequeueThreshold(
 	mockDeadLetterQueueClient.On("EnqueueMessage", mock.Anything, mock.Anything, mock.Anything).Return(azqueue.EnqueueMessagesResponse{}, nil)
 
 	mockReadAndSendUsecase := MockReadAndSendUsecase{}
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, ctx: context.Background(), usecase: &mockReadAndSendUsecase}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, usecase: &mockReadAndSendUsecase}
 
 	message := createMessageOverDequeueThreshold()
 	overThreshold := queueHandler.overDeliveryThreshold(message)
@@ -398,7 +398,7 @@ func Test_overDeliveryThreshold_overThresholdAndUnableToDeadLetter(t *testing.T)
 	mockDeadLetterQueueClient := MockQueueClient{}
 	mockDeadLetterQueueClient.On("EnqueueMessage", mock.Anything, mock.Anything, mock.Anything).Return(azqueue.EnqueueMessagesResponse{}, errors.New("DLQ failed"))
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, ctx: context.Background()}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient}
 
 	message := createMessageOverDequeueThreshold()
 	overThreshold := queueHandler.overDeliveryThreshold(message)
@@ -414,7 +414,7 @@ func Test_deadLetter_addedMessageToDLQAndSuccessfullyDeletedMessageFromOriginalQ
 	mockQueueClient := MockQueueClient{}
 	mockQueueClient.On("DeleteMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(azqueue.DeleteMessageResponse{}, nil)
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, ctx: context.Background()}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient}
 
 	message := createMessageOverDequeueThreshold()
 	err := queueHandler.deadLetter(message)
@@ -431,7 +431,7 @@ func Test_deadLetter_cannotAddMessageToDLQ(t *testing.T) {
 	mockQueueClient := MockQueueClient{}
 	mockQueueClient.On("DeleteMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(azqueue.DeleteMessageResponse{}, nil)
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, ctx: context.Background()}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient}
 
 	message := createMessageOverDequeueThreshold()
 	err := queueHandler.deadLetter(message)
@@ -448,7 +448,7 @@ func Test_deadLetter_failedToDeleteMessageFromOriginalQueue(t *testing.T) {
 	mockQueueClient := MockQueueClient{}
 	mockQueueClient.On("DeleteMessage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(azqueue.DeleteMessageResponse{}, errors.New("couldn't delete message from original queue"))
 
-	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient, ctx: context.Background()}
+	queueHandler := QueueHandler{queueClient: &mockQueueClient, deadLetterQueueClient: &mockDeadLetterQueueClient}
 
 	message := createMessageOverDequeueThreshold()
 	err := queueHandler.deadLetter(message)


### PR DESCRIPTION
# Remove Context from the `QueueHandler` Struct

I removed the `context.Context` from the `QueueHandler` struct.  The places it was used now passes in `context.Background()`, and I updated the tests to no longer pass in a context when constructing a `QueueHandler`.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1077

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added GoDocs where required
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
