### PR TITLE
Enable Azure Function deploy in more environments

### DIFF
--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -100,3 +100,14 @@ jobs:
         app-name: ${{ inputs.APP }}
         slot-name: production
         images: '${{ inputs.REGISTRY }}/${{ inputs.REPO }}:${{ github.sha }}'
+
+  function-deploy:
+    name: Function Deploy
+    needs: terraform-deploy
+    uses: ./.github/workflows/functions-deploy.yml
+    with:
+      ENVIRONMENT: ${{ inputs.ENVIRONMENT }}
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/deploy_reusable.yml
+++ b/.github/workflows/deploy_reusable.yml
@@ -103,7 +103,6 @@ jobs:
 
   function-deploy:
     name: Function Deploy
-    needs: terraform-deploy
     uses: ./.github/workflows/functions-deploy.yml
     with:
       ENVIRONMENT: ${{ inputs.ENVIRONMENT }}

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -7,23 +7,12 @@ on:
       ENVIRONMENT:
         required: true
         type: string
-      REGISTRY:
-        required: true
-        type: string
-      REPO:
-        required: true
-        type: string
-      APP:
-        required: true
-        type: string
     secrets:
       AZURE_CLIENT_ID:
         required: true
       AZURE_TENANT_ID:
         required: true
       AZURE_SUBSCRIPTION_ID:
-        required: true
-      AZURE_FUNCTIONAPP_PUBLISH_PROFILE:
         required: true
 
 permissions:

--- a/.github/workflows/internal-deploy.yml
+++ b/.github/workflows/internal-deploy.yml
@@ -2,9 +2,6 @@ name: Deploy to Internal Environment
 
 on:
   workflow_call:
-    secrets:
-      AZURE_FUNCTIONAPP_PUBLISH_PROFILE_INTERNAL:
-        required: true
   push:
     branches:
       - internal
@@ -36,18 +33,3 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
-  function-deploy:
-    name: Function Deploy
-    needs: terraform-deploy
-    uses: ./.github/workflows/functions-deploy.yml
-    with:
-      ENVIRONMENT: internal
-      REPO: report-stream-sftp-ingest
-      APP: ${{ needs.terraform-deploy.outputs.APP }}
-      REGISTRY: ${{ needs.terraform-deploy.outputs.REGISTRY }}
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      AZURE_FUNCTIONAPP_PUBLISH_PROFILE: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE_INTERNAL }}


### PR DESCRIPTION
# Enable Azure Function deploy in more environments
We moved the Azure Function deploy code out of `internal-deploy.yml` and into `deploy_reusable.yml` so it should work in all environments. We also cleaned up unused variables and adjusted the step dependencies based on the new structure. We ran this in both `internal` and `dev` environments and confirmed that the Azure Function was created

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1080

