### PR TITLE
Ignore tags in TF that are added by CDC

### DIFF
--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -5,6 +5,13 @@ resource "azurerm_container_registry" "registry" {
   location            = data.azurerm_resource_group.group.location
   sku                 = "Standard"
   admin_enabled       = true
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }
 
 # Create the staging service plan
@@ -15,6 +22,13 @@ resource "azurerm_service_plan" "plan" {
   os_type                = "Linux"
   sku_name               = local.higher_environment_level ? "P1v3" : "P0v3"
   zone_balancing_enabled = local.higher_environment_level
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }
 
 # Create the staging App Service
@@ -23,6 +37,13 @@ resource "azurerm_linux_web_app" "sftp" {
   resource_group_name = data.azurerm_resource_group.group.name
   location            = azurerm_service_plan.plan.location
   service_plan_id     = azurerm_service_plan.plan.id
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 
   https_only = true
 
@@ -91,6 +112,12 @@ resource "azurerm_monitor_autoscale_setting" "sftp_autoscale" {
   location            = data.azurerm_resource_group.group.location
   target_resource_id  = azurerm_service_plan.plan.id
 
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 
   profile {
     name = "defaultProfile"

--- a/operations/template/event.tf
+++ b/operations/template/event.tf
@@ -9,6 +9,13 @@ resource "azurerm_eventgrid_system_topic" "topic" {
   identity {
     type = "SystemAssigned"
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }
 
 resource "azurerm_eventgrid_system_topic_event_subscription" "topic_sub" {

--- a/operations/template/functions.tf
+++ b/operations/template/functions.tf
@@ -32,4 +32,11 @@ resource "azurerm_linux_function_app" "polling_trigger_function_app" {
       node_version = "20"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }

--- a/operations/template/key.tf
+++ b/operations/template/key.tf
@@ -8,6 +8,13 @@ resource "azurerm_key_vault" "key_storage" {
   tenant_id = data.azurerm_client_config.current.tenant_id
 
   purge_protection_enabled = false
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }
 
 resource "azurerm_key_vault_access_policy" "allow_github_deployer" {

--- a/operations/template/logs.tf
+++ b/operations/template/logs.tf
@@ -3,12 +3,26 @@ resource "azurerm_log_analytics_workspace" "logs_workspace" {
 
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }
 
 resource "azurerm_log_analytics_query_pack" "application_logs_pack" {
   name                = "RS SFTP Application Logs"
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }
 
 resource "azurerm_log_analytics_query_pack_query" "example" {

--- a/operations/template/net.tf
+++ b/operations/template/net.tf
@@ -39,6 +39,12 @@ resource "azurerm_network_security_group" "app_security_group" {
   name                = "sftp-app-security-group"
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }
 
 resource "azurerm_network_security_rule" "App_Splunk_UF_omhsinf" {

--- a/operations/template/storage.tf
+++ b/operations/template/storage.tf
@@ -9,6 +9,13 @@ resource "azurerm_storage_account" "storage" {
   is_hns_enabled                  = true
   sftp_enabled                    = true
   min_tls_version                 = "TLS1_2"
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags because the CDC sets these automagically
+      tags,
+    ]
+  }
 }
 
 resource "azurerm_storage_container" "sftp_container" {


### PR DESCRIPTION
# Ignore tags in TF that are added by CDC
The CDC auto-tags some resources, and every time we apply terraform, these tags are deleted (and then later auto-re-applied). Because we no longer have permission to change some TF resources, these automatic changes are blocking deploy in _all_ CDC-owned environments.

We will still need to be able to change network security groups eventually since we manage those resources and haven't yet created them in production, but this change at least will let us deploy to staging and dev for now

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1153
