### PR TITLE
Pin Dependencies to Specific Versions for the Azure Function

### DIFF
--- a/azure_functions/package-lock.json
+++ b/azure_functions/package-lock.json
@@ -8,13 +8,13 @@
       "name": "azure_functions",
       "version": "1.0.0",
       "dependencies": {
-        "@azure/functions": "^4.0.0",
-        "@azure/storage-queue": "^12.22.0"
+        "@azure/functions": "4.5.0",
+        "@azure/storage-queue": "12.23.0"
       },
       "devDependencies": {
-        "@types/node": "^20.x",
-        "rimraf": "^5.0.0",
-        "typescript": "^5.0.0"
+        "@types/node": "20.14.13",
+        "rimraf": "5.0.9",
+        "typescript": "5.5.4"
       }
     },
     "node_modules/@azure/abort-controller": {

--- a/azure_functions/package.json
+++ b/azure_functions/package.json
@@ -11,13 +11,13 @@
     "test": "echo \"No tests yet...\""
   },
   "dependencies": {
-    "@azure/functions": "^4.0.0",
-    "@azure/storage-queue": "^12.22.0"
+    "@azure/functions": "4.5.0",
+    "@azure/storage-queue": "12.23.0"
   },
   "devDependencies": {
-    "@types/node": "^20.x",
-    "rimraf": "^5.0.0",
-    "typescript": "^5.0.0"
+    "@types/node": "20.14.13",
+    "rimraf": "5.0.9",
+    "typescript": "5.5.4"
   },
   "main": "dist/src/{index.js,functions/*.js}"
 }


### PR DESCRIPTION
# Pin Dependencies to Specific Versions for the Azure Function

Changed the dependencies for the Azure function in `package.json` (and therefore `package-lock.json`) to reference specific versions.  I.e. removing the `^` from the version strings.  We use Renovate and it can keep the versions up-to-date.

## Issue

_None_.
