### PR TITLE
Bump version of fast-xml-parser

### DIFF
--- a/azure_functions/package-lock.json
+++ b/azure_functions/package-lock.json
@@ -400,9 +400,9 @@
       "dev": true
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.0.tgz",
-      "integrity": "sha512-kLY3jFlwIYwBNDojclKsNAC12sfD6NwW74QB2CoNGPvtVxjliYehVunB3HYyNi+n4Tt1dAcgwYvmKF/Z18flqg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
+      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
       "funding": [
         {
           "type": "github",
@@ -413,6 +413,7 @@
           "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },


### PR DESCRIPTION
The azure-functions sdk is using an older version of `fast-xml-parser` that has a vulnerability.  This PR contains the automatic fix that is obtained by running `npm audit` 

## Issue

This PR was created from a security alert about one of our non-direct dependencies.

