### PR TITLE
No IO Client

### DIFF
--- a/codeCoverageFilter.sh
+++ b/codeCoverageFilter.sh
@@ -11,7 +11,7 @@ EXCLUDE_FILES=(
   github.com/CDCgov/reportstream-sftp-ingestion/senders/local_sender.go
   github.com/CDCgov/reportstream-sftp-ingestion/mocks/blob_handler.go
   github.com/CDCgov/reportstream-sftp-ingestion/utils/constants.go
-
+  github.com/CDCgov/reportstream-sftp-ingestion/sftp/pkg_sftp.go
 )
 
 for exclusion in "${EXCLUDE_FILES[@]}"

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -17,7 +17,7 @@ import (
 
 type SftpHandler struct {
 	sshClient        *ssh.Client
-	sftpWrapper      SftpWrapper
+	sftpClient       SftpWrapper
 	blobHandler      usecases.BlobHandler
 	credentialGetter secrets.CredentialGetter
 	zipHandler       zip.ZipHandlerInterface
@@ -111,7 +111,7 @@ func NewSftpHandler() (*SftpHandler, error) {
 
 	return &SftpHandler{
 		sshClient:        sshClient,
-		sftpWrapper:      sftpClient,
+		sftpClient:       sftpClient,
 		blobHandler:      blobHandler,
 		credentialGetter: credentialGetter,
 		zipHandler:       zipHandler,
@@ -147,8 +147,8 @@ func getPublicKeysForSshClient(credentialGetter secrets.CredentialGetter) (ssh.S
 
 func (receiver *SftpHandler) Close() {
 	slog.Info("About to close SFTP handler")
-	if receiver.sftpWrapper != nil {
-		err := receiver.sftpWrapper.Close()
+	if receiver.sftpClient != nil {
+		err := receiver.sftpClient.Close()
 		if err != nil {
 			slog.Error("Failed to close SFTP client", slog.Any(utils.ErrorKey, err))
 		}
@@ -171,7 +171,7 @@ func (receiver *SftpHandler) CopyFiles() {
 		return
 	}
 
-	fileInfos, err := receiver.sftpWrapper.ReadDir(sftpStartingDirectory)
+	fileInfos, err := receiver.sftpClient.ReadDir(sftpStartingDirectory)
 	slog.Info("starting directory", slog.String("start dir", sftpStartingDirectory))
 	if err != nil {
 		slog.Error("Failed to read directory", slog.Any(utils.ErrorKey, err))
@@ -215,7 +215,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		return
 	}
 
-	file, err := receiver.sftpWrapper.Open(directory + "/" + fileInfo.Name())
+	file, err := receiver.sftpClient.Open(directory + "/" + fileInfo.Name())
 
 	if err != nil {
 		slog.Error("Failed to open file", slog.Any(utils.ErrorKey, err))
@@ -268,7 +268,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		slog.Error("Failed to remove file from local server", slog.Any(utils.ErrorKey, err), slog.String("name", fileInfo.Name()))
 	}
 
-	err = receiver.sftpWrapper.Remove(directory + "/" + fileInfo.Name())
+	err = receiver.sftpClient.Remove(directory + "/" + fileInfo.Name())
 	if err != nil {
 		slog.Error("Failed to remove file from SFTP server", slog.Any(utils.ErrorKey, err))
 		return

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -6,7 +6,6 @@ import (
 	"github.com/CDCgov/reportstream-sftp-ingestion/usecases"
 	"github.com/CDCgov/reportstream-sftp-ingestion/utils"
 	"github.com/CDCgov/reportstream-sftp-ingestion/zip"
-	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	"io"
 	"log/slog"
@@ -18,18 +17,10 @@ import (
 
 type SftpHandler struct {
 	sshClient        *ssh.Client
-	sftpClient       SftpClient
+	sftpClient       SftpWrapper
 	blobHandler      usecases.BlobHandler
-	ioClient         IoClient
 	credentialGetter secrets.CredentialGetter
 	zipHandler       zip.ZipHandlerInterface
-}
-
-type SftpClient interface {
-	ReadDir(path string) ([]os.FileInfo, error)
-	Open(path string) (*sftp.File, error)
-	Close() error
-	Remove(path string) error
 }
 
 func NewSftpHandler() (*SftpHandler, error) {
@@ -99,7 +90,7 @@ func NewSftpHandler() (*SftpHandler, error) {
 		return nil, err
 	}
 
-	sftpClient, err := sftp.NewClient(sshClient)
+	sftpClient, err := NewPkgSftpImplementation(sshClient)
 	if err != nil {
 		slog.Error("Failed to make SFTP client ", slog.Any(utils.ErrorKey, err))
 		return nil, err
@@ -110,8 +101,6 @@ func NewSftpHandler() (*SftpHandler, error) {
 		slog.Error("Failed to init Azure blob client", slog.Any(utils.ErrorKey, err))
 		return nil, err
 	}
-
-	ioWrapper := IoWrapper{}
 
 	zipHandler, err := zip.NewZipHandler()
 
@@ -124,7 +113,6 @@ func NewSftpHandler() (*SftpHandler, error) {
 		sshClient:        sshClient,
 		sftpClient:       sftpClient,
 		blobHandler:      blobHandler,
-		ioClient:         &ioWrapper,
 		credentialGetter: credentialGetter,
 		zipHandler:       zipHandler,
 	}, nil
@@ -235,7 +223,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 	}
 
 	slog.Info("file opened", slog.String("name", fileInfo.Name()), slog.Any("file", file))
-	fileBytes, err := receiver.ioClient.ReadBytesFromFile(file)
+	fileBytes, err := io.ReadAll(file)
 	if err != nil {
 		slog.Error("Failed to read file", slog.Any(utils.ErrorKey, err))
 		return
@@ -287,16 +275,4 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 	}
 
 	slog.Info("Successfully copied file and removed from SFTP server", slog.Any("file name", fileInfo.Name()))
-
-}
-
-type IoClient interface {
-	ReadBytesFromFile(file *sftp.File) ([]byte, error)
-}
-
-type IoWrapper struct {
-}
-
-func (receiver *IoWrapper) ReadBytesFromFile(file *sftp.File) ([]byte, error) {
-	return io.ReadAll(file)
 }

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -17,7 +17,7 @@ import (
 
 type SftpHandler struct {
 	sshClient        *ssh.Client
-	sftpClient       SftpWrapper
+	sftpWrapper      SftpWrapper
 	blobHandler      usecases.BlobHandler
 	credentialGetter secrets.CredentialGetter
 	zipHandler       zip.ZipHandlerInterface
@@ -111,7 +111,7 @@ func NewSftpHandler() (*SftpHandler, error) {
 
 	return &SftpHandler{
 		sshClient:        sshClient,
-		sftpClient:       sftpClient,
+		sftpWrapper:      sftpClient,
 		blobHandler:      blobHandler,
 		credentialGetter: credentialGetter,
 		zipHandler:       zipHandler,
@@ -147,8 +147,8 @@ func getPublicKeysForSshClient(credentialGetter secrets.CredentialGetter) (ssh.S
 
 func (receiver *SftpHandler) Close() {
 	slog.Info("About to close SFTP handler")
-	if receiver.sftpClient != nil {
-		err := receiver.sftpClient.Close()
+	if receiver.sftpWrapper != nil {
+		err := receiver.sftpWrapper.Close()
 		if err != nil {
 			slog.Error("Failed to close SFTP client", slog.Any(utils.ErrorKey, err))
 		}
@@ -171,7 +171,7 @@ func (receiver *SftpHandler) CopyFiles() {
 		return
 	}
 
-	fileInfos, err := receiver.sftpClient.ReadDir(sftpStartingDirectory)
+	fileInfos, err := receiver.sftpWrapper.ReadDir(sftpStartingDirectory)
 	slog.Info("starting directory", slog.String("start dir", sftpStartingDirectory))
 	if err != nil {
 		slog.Error("Failed to read directory", slog.Any(utils.ErrorKey, err))
@@ -215,7 +215,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		return
 	}
 
-	file, err := receiver.sftpClient.Open(directory + "/" + fileInfo.Name())
+	file, err := receiver.sftpWrapper.Open(directory + "/" + fileInfo.Name())
 
 	if err != nil {
 		slog.Error("Failed to open file", slog.Any(utils.ErrorKey, err))
@@ -268,7 +268,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		slog.Error("Failed to remove file from local server", slog.Any(utils.ErrorKey, err), slog.String("name", fileInfo.Name()))
 	}
 
-	err = receiver.sftpClient.Remove(directory + "/" + fileInfo.Name())
+	err = receiver.sftpWrapper.Remove(directory + "/" + fileInfo.Name())
 	if err != nil {
 		slog.Error("Failed to remove file from SFTP server", slog.Any(utils.ErrorKey, err))
 		return

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -211,7 +211,7 @@ func (receiver *SftpHandler) CopyFiles() {
 func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, directory string) {
 	slog.Info("Considering file", slog.String("name", fileInfo.Name()), slog.Int("number", index))
 	if fileInfo.IsDir() {
-		slog.Info("Skipping directory", slog.String("file name", fileInfo.Name()))
+		slog.Info("Skipping directory", slog.String(utils.FileNameKey, fileInfo.Name()))
 		return
 	}
 
@@ -241,11 +241,11 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		return
 	}
 
-	slog.Info("About to consider whether this is a zip", slog.String("file name", fileInfo.Name()))
+	slog.Info("About to consider whether this is a zip", slog.String(utils.FileNameKey, fileInfo.Name()))
 
 	// TODO - if non-CA customers want us to retrieve non-zip files, will need to update this `if`
 	if !strings.Contains(fileInfo.Name(), ".zip") {
-		slog.Info("Skipping file because it is not a zip file", slog.String("file name", fileInfo.Name()))
+		slog.Info("Skipping file because it is not a zip file", slog.String(utils.FileNameKey, fileInfo.Name()))
 		return
 	}
 	// write file to local filesystem
@@ -274,5 +274,5 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		return
 	}
 
-	slog.Info("Successfully copied file and removed from SFTP server", slog.Any("file name", fileInfo.Name()))
+	slog.Info("Successfully copied file and removed from SFTP server", slog.Any(utils.FileNameKey, fileInfo.Name()))
 }

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -107,7 +107,7 @@ func Test_CopyFiles_SuccessfullyCopiesFiles(t *testing.T) {
 	mockZipHandler := &MockZipHandler{}
 	mockZipHandler.On("Unzip", mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, credentialGetter: mockCredentialGetter, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, credentialGetter: mockCredentialGetter, zipHandler: mockZipHandler}
 
 	sftpHandler.CopyFiles()
 
@@ -133,7 +133,7 @@ func Test_CopyFiles_FailsToReadDirectory_LogsError(t *testing.T) {
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	mockCredentialGetter.On("GetSecret", mock.Anything).Return("dogcow", nil)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient, credentialGetter: mockCredentialGetter}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, credentialGetter: mockCredentialGetter}
 
 	sftpHandler.CopyFiles()
 
@@ -163,7 +163,7 @@ func Test_copySingleFile_CopiesFile(t *testing.T) {
 	mockZipHandler := &MockZipHandler{}
 	mockZipHandler.On("Unzip", mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -189,7 +189,7 @@ func Test_copySingleFile_SkipsDirectory_LogsError(t *testing.T) {
 	fileDirectory := filepath.Join("..", "..", "mock_data")
 	fileInfo, _ := os.Stat(fileDirectory)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	assert.Contains(t, buffer.String(), "Skipping directory")
@@ -209,7 +209,7 @@ func Test_copySingleFile_FailsToOpenFile_LogsError(t *testing.T) {
 	filePath := filepath.Join(fileDirectory, "copy_file_test.txt.zip")
 	fileInfo, _ := os.Stat(filePath)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockSftpClient.AssertCalled(t, "Open", mock.Anything)
@@ -230,7 +230,7 @@ func Test_copySingleFile_FailsToReadFile_LogsError(t *testing.T) {
 	filePath := filepath.Join(fileDirectory, "copy_file_test.txt.zip")
 	fileInfo, _ := os.Stat(filePath)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockSftpClient.AssertCalled(t, "Open", mock.Anything)
@@ -259,7 +259,7 @@ func Test_copySingleFile_FileIsNotZipFile_LogThatFileIsSkipped(t *testing.T) {
 	mockZipHandler := &MockZipHandler{}
 	mockZipHandler.On("Unzip", mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -293,7 +293,7 @@ func Test_copySingleFile_FailsToUploadFile_LogsError(t *testing.T) {
 	mockZipHandler := &MockZipHandler{}
 	mockZipHandler.On("Unzip", mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -323,7 +323,7 @@ func Test_copySingleFile_FailsToUnzipFile_LogsError(t *testing.T) {
 	mockBlobHandler := &mocks.MockBlobHandler{}
 	mockBlobHandler.On("UploadFile", mock.Anything, mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -355,7 +355,7 @@ func Test_copySingleFile_FailsToDeleteFileFromSFTPServer_LogsErrorAndReturn(t *t
 	mockBlobHandler := &mocks.MockBlobHandler{}
 	mockBlobHandler.On("UploadFile", mock.Anything, mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -387,7 +387,7 @@ func Test_copySingleFile_DeletesFileFromSFTPServer(t *testing.T) {
 	mockBlobHandler := &mocks.MockBlobHandler{}
 	mockBlobHandler.On("UploadFile", mock.Anything, mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -107,7 +107,7 @@ func Test_CopyFiles_SuccessfullyCopiesFiles(t *testing.T) {
 	mockZipHandler := &MockZipHandler{}
 	mockZipHandler.On("Unzip", mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, credentialGetter: mockCredentialGetter, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, credentialGetter: mockCredentialGetter, zipHandler: mockZipHandler}
 
 	sftpHandler.CopyFiles()
 
@@ -133,7 +133,7 @@ func Test_CopyFiles_FailsToReadDirectory_LogsError(t *testing.T) {
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	mockCredentialGetter.On("GetSecret", mock.Anything).Return("dogcow", nil)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, credentialGetter: mockCredentialGetter}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient, credentialGetter: mockCredentialGetter}
 
 	sftpHandler.CopyFiles()
 
@@ -163,7 +163,7 @@ func Test_copySingleFile_CopiesFile(t *testing.T) {
 	mockZipHandler := &MockZipHandler{}
 	mockZipHandler.On("Unzip", mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -189,7 +189,7 @@ func Test_copySingleFile_SkipsDirectory_LogsError(t *testing.T) {
 	fileDirectory := filepath.Join("..", "..", "mock_data")
 	fileInfo, _ := os.Stat(fileDirectory)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	assert.Contains(t, buffer.String(), "Skipping directory")
@@ -209,7 +209,7 @@ func Test_copySingleFile_FailsToOpenFile_LogsError(t *testing.T) {
 	filePath := filepath.Join(fileDirectory, "copy_file_test.txt.zip")
 	fileInfo, _ := os.Stat(filePath)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockSftpClient.AssertCalled(t, "Open", mock.Anything)
@@ -230,7 +230,7 @@ func Test_copySingleFile_FailsToReadFile_LogsError(t *testing.T) {
 	filePath := filepath.Join(fileDirectory, "copy_file_test.txt.zip")
 	fileInfo, _ := os.Stat(filePath)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockSftpClient.AssertCalled(t, "Open", mock.Anything)
@@ -259,7 +259,7 @@ func Test_copySingleFile_FileIsNotZipFile_LogThatFileIsSkipped(t *testing.T) {
 	mockZipHandler := &MockZipHandler{}
 	mockZipHandler.On("Unzip", mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -293,7 +293,7 @@ func Test_copySingleFile_FailsToUploadFile_LogsError(t *testing.T) {
 	mockZipHandler := &MockZipHandler{}
 	mockZipHandler.On("Unzip", mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -323,7 +323,7 @@ func Test_copySingleFile_FailsToUnzipFile_LogsError(t *testing.T) {
 	mockBlobHandler := &mocks.MockBlobHandler{}
 	mockBlobHandler.On("UploadFile", mock.Anything, mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -355,7 +355,7 @@ func Test_copySingleFile_FailsToDeleteFileFromSFTPServer_LogsErrorAndReturn(t *t
 	mockBlobHandler := &mocks.MockBlobHandler{}
 	mockBlobHandler.On("UploadFile", mock.Anything, mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
@@ -387,7 +387,7 @@ func Test_copySingleFile_DeletesFileFromSFTPServer(t *testing.T) {
 	mockBlobHandler := &mocks.MockBlobHandler{}
 	mockBlobHandler.On("UploadFile", mock.Anything, mock.Anything).Return(nil)
 
-	sftpHandler := SftpHandler{sftpWrapper: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
+	sftpHandler := SftpHandler{sftpClient: mockSftpClient, blobHandler: mockBlobHandler, zipHandler: mockZipHandler}
 	sftpHandler.copySingleFile(fileInfo, 1, fileDirectory)
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)

--- a/src/sftp/pkg_sftp.go
+++ b/src/sftp/pkg_sftp.go
@@ -1,0 +1,42 @@
+package sftp
+
+import (
+	"github.com/pkg/sftp"
+	"golang.org/x/crypto/ssh"
+	"io"
+	"os"
+)
+
+type PkgSftpImplementation struct {
+	client *sftp.Client
+}
+
+func NewPkgSftpImplementation(sshClient *ssh.Client) (PkgSftpImplementation, error) {
+	sftpClient, err := sftp.NewClient(sshClient)
+	if err != nil {
+		return PkgSftpImplementation{}, err
+	}
+
+	return PkgSftpImplementation{client: sftpClient}, nil
+}
+
+func (p PkgSftpImplementation) ReadDir(path string) ([]os.FileInfo, error) {
+	return p.client.ReadDir(path)
+}
+
+func (p PkgSftpImplementation) Open(path string) (io.Reader, error) {
+	file, err := p.client.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func (p PkgSftpImplementation) Close() error {
+	return p.client.Close()
+}
+
+func (p PkgSftpImplementation) Remove(path string) error {
+	return p.client.Remove(path)
+}

--- a/src/sftp/wrapper.go
+++ b/src/sftp/wrapper.go
@@ -1,0 +1,13 @@
+package sftp
+
+import (
+	"io"
+	"os"
+)
+
+type SftpWrapper interface {
+	ReadDir(path string) ([]os.FileInfo, error)
+	Open(path string) (io.Reader, error)
+	Close() error
+	Remove(path string) error
+}

--- a/src/utils/constants.go
+++ b/src/utils/constants.go
@@ -24,3 +24,7 @@ const ReportStreamNonTransientFailure = "400"
 // Use this when logging an error.
 // E.g. `slog.Warn("Failed to construct the ReportStream senders", slog.Any(utils.ErrorKey, err))`
 const ErrorKey = "error"
+
+// Used in logging.
+// E.g. `slog.Info("Successfully copied file and removed from SFTP server", slog.Any(utils.FileNameKey, fileInfo.Name()))`
+const FileNameKey = "file name"

--- a/src/zip/zip.go
+++ b/src/zip/zip.go
@@ -92,17 +92,17 @@ func (zipHandler ZipHandler) Unzip(zipFilePath string) error {
 }
 
 func (zipHandler ZipHandler) ExtractAndUploadSingleFile(f *zip.File, zipPassword string, errorList []FileError) []FileError {
-	slog.Info("preparing to process file", slog.String("file name", f.Name))
+	slog.Info("preparing to process file", slog.String(utils.FileNameKey, f.Name))
 
 	// TODO - should we warn or error if not encrypted? This would vary per customer
 	if f.IsEncrypted() {
-		slog.Info("setting password for file", slog.String("file name", f.Name))
+		slog.Info("setting password for file", slog.String(utils.FileNameKey, f.Name))
 		f.SetPassword(zipPassword)
 	}
 
 	fileReader, err := f.Open()
 	if err != nil {
-		slog.Error("Failed to open file", slog.String("file name", f.Name), slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to open file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err))
 		errorList = append(errorList, FileError{Filename: f.Name, ErrorMessage: err.Error()})
 		return errorList
 	}
@@ -110,7 +110,7 @@ func (zipHandler ZipHandler) ExtractAndUploadSingleFile(f *zip.File, zipPassword
 
 	buf, err := io.ReadAll(fileReader)
 	if err != nil {
-		slog.Error("Failed to read file", slog.String("file name", f.Name), slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to read file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err))
 		errorList = append(errorList, FileError{Filename: f.Name, ErrorMessage: err.Error()})
 		return errorList
 	}
@@ -118,11 +118,11 @@ func (zipHandler ZipHandler) ExtractAndUploadSingleFile(f *zip.File, zipPassword
 	err = zipHandler.blobHandler.UploadFile(buf, filepath.Join(utils.MessageStartingFolderPath, f.FileInfo().Name()))
 
 	if err != nil {
-		slog.Error("Failed to upload file", slog.String("file name", f.Name), slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to upload file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err))
 		errorList = append(errorList, FileError{Filename: f.Name, ErrorMessage: err.Error()})
 		return errorList
 	}
-	slog.Info("uploaded file to blob for import", slog.String("file name", f.Name))
+	slog.Info("uploaded file to blob for import", slog.String(utils.FileNameKey, f.Name))
 	return errorList
 }
 


### PR DESCRIPTION
## Description

We had an `IoClient` interface and subsequent wrapper so we could mock reading from an SFTP server.  We needed this because our SFTP client (and interface) returned `*sftp.File` that couldn't be mocked to return anything.

That's lame, and I also didn't like this `IoClient` thing either.

So, I put the third-party SFTP client behind a wrapper that dictates what we want (an `io.Reader`), not what the third-party SFTP client returns (an `*sftp.File`).  I then made a humble struct implementation that converts what the SFTP client returns (`*sftp.File`) to what we want (`io.Reader`).  We can then make a mock implementation of the wrapper to return whatever `io.Reader` we want, which we do in the unit tests.

I also split `sftp.go` into other files for the sake of organization.  `handler.go` has all the handler code.  `wrapper.go` just has the wrapper interface.  `pkg_sftp.go` contains the wrapper implementation for the pkg/sftp third-party dependency.

Lastly, I ignore `pkg_sftp.go` from code coverage because it is a humble object.

## Issue

_None_.

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
- [x] I have added GoDocs where required
- [x] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
