### PR TITLE
1077: Delete the File from CA SFTP for Realz

### DIFF
--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -32,10 +32,10 @@ func NewSftpHandler() (*SftpHandler, error) {
 		return nil, err
 	}
 
-	pem, err := getPublicKeysForSshClient(credentialGetter)
-	if err != nil {
-		return nil, err
-	}
+	//pem, err := getPublicKeysForSshClient(credentialGetter)
+	//if err != nil {
+	//	return nil, err
+	//}
 
 	serverKeyName := os.Getenv("SFTP_SERVER_PUBLIC_KEY_NAME")
 
@@ -70,7 +70,7 @@ func NewSftpHandler() (*SftpHandler, error) {
 	config := &ssh.ClientConfig{
 		User: sftpUser,
 		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(pem),
+			//ssh.PublicKeys(pem),
 			ssh.Password(sftpPassword),
 		},
 		HostKeyCallback: hostKeyCallback,

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -209,7 +209,7 @@ func (receiver *SftpHandler) CopyFiles() {
 // copySingleFile moves a single file from an external SFTP server to our blob storage. Zip files go to an `unzip`
 // folder and then we call the zipHandler.Unzip. Other files go to `import` to begin processing
 func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, directory string) {
-	slog.Info("Considering file", slog.String("name", fileInfo.Name()), slog.Int("number", index))
+	slog.Info("Considering file", slog.String(utils.FileNameKey, fileInfo.Name()), slog.Int("number", index))
 	if fileInfo.IsDir() {
 		slog.Info("Skipping directory", slog.String(utils.FileNameKey, fileInfo.Name()))
 		return
@@ -217,21 +217,22 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 
 	fullFilePath := directory + "/" + fileInfo.Name()
 
-	file, err := receiver.sftpClient.Open(fullFilePath)
+	fileReadCloser, err := receiver.sftpClient.Open(fullFilePath)
 
 	if err != nil {
-		slog.Error("Failed to open file", slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to open file", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))
 		return
 	}
 
-	slog.Info("file opened", slog.String("name", fileInfo.Name()), slog.Any("file", file))
-	fileBytes, err := io.ReadAll(file)
+	slog.Info("file opened", slog.String(utils.FileNameKey, fullFilePath))
+
+	fileBytes, err := io.ReadAll(fileReadCloser)
 	if err != nil {
-		slog.Error("Failed to read file", slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to read file", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))
 		return
 	}
 
-	err = file.Close()
+	err = fileReadCloser.Close()
 	if err != nil {
 		slog.Error("Failed to close file after reading", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))
 		return

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -234,8 +234,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 	err = file.Close()
 	if err != nil {
 		slog.Error("Failed to close file after reading", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))
-		// Don't return early if we can't close, we want the other things to complete.
-		// It's possible that for certain SFTP servers that follow-on SFTP commands will fail if this close failed.
+		return
 	}
 
 	var blobPath string

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -32,6 +32,7 @@ func NewSftpHandler() (*SftpHandler, error) {
 		return nil, err
 	}
 
+	// TODO uncomment code when partner is setup to receive key
 	//pem, err := getPublicKeysForSshClient(credentialGetter)
 	//if err != nil {
 	//	return nil, err
@@ -67,6 +68,7 @@ func NewSftpHandler() (*SftpHandler, error) {
 		return nil, err
 	}
 
+	// TODO uncomment code when partner is setup to receive key
 	config := &ssh.ClientConfig{
 		User: sftpUser,
 		Auth: []ssh.AuthMethod{

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -215,7 +215,9 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		return
 	}
 
-	file, err := receiver.sftpClient.Open(directory + "/" + fileInfo.Name())
+	fullFilePath := directory + "/" + fileInfo.Name()
+
+	file, err := receiver.sftpClient.Open(fullFilePath)
 
 	if err != nil {
 		slog.Error("Failed to open file", slog.Any(utils.ErrorKey, err))
@@ -268,11 +270,11 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		slog.Error("Failed to remove file from local server", slog.Any(utils.ErrorKey, err), slog.String("name", fileInfo.Name()))
 	}
 
-	err = receiver.sftpClient.Remove(directory + "/" + fileInfo.Name())
+	err = receiver.sftpClient.Remove(fullFilePath)
 	if err != nil {
-		slog.Error("Failed to remove file from SFTP server", slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to remove file from SFTP server", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))
 		return
 	}
 
-	slog.Info("Successfully copied file and removed from SFTP server", slog.Any(utils.FileNameKey, fileInfo.Name()))
+	slog.Info("Successfully copied file and removed from SFTP server", slog.Any(utils.FileNameKey, fullFilePath))
 }

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -421,9 +421,9 @@ func (receiver *MockSftpWrapper) ReadDir(path string) ([]os.FileInfo, error) {
 	return args.Get(0).([]os.FileInfo), args.Error(1)
 }
 
-func (receiver *MockSftpWrapper) Open(path string) (io.Reader, error) {
+func (receiver *MockSftpWrapper) Open(path string) (io.ReadCloser, error) {
 	args := receiver.Called(path)
-	return args.Get(0).(io.Reader), args.Error(1)
+	return args.Get(0).(io.ReadCloser), args.Error(1)
 }
 
 func (receiver *MockSftpWrapper) Close() error {
@@ -445,7 +445,7 @@ func (receiver *MockZipHandler) Unzip(zipFilePath string) error {
 	return args.Error(0)
 }
 
-func (receiver *MockZipHandler) ExtractAndUploadSingleFile(f *yekazip.File, zipPassword string, errorList []zip.FileError) []zip.FileError {
+func (receiver *MockZipHandler) ExtractAndUploadSingleFile(f *yekazip.File, zipPassword string, zipFile string, errorList []zip.FileError) []zip.FileError {
 	args := receiver.Called(f, zipPassword, errorList)
 	return args.Get(0).([]zip.FileError)
 }

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -154,7 +154,7 @@ func Test_copySingleFile_CopiesFile(t *testing.T) {
 	fileBytes, _ := os.ReadFile(filePath)
 
 	mockSftpClient := new(MockSftpWrapper)
-	mockSftpClient.On("Open", mock.Anything).Return(bytes.NewReader(fileBytes), nil)
+	mockSftpClient.On("Open", mock.Anything).Return(io.NopCloser(bytes.NewReader(fileBytes)), nil)
 	mockSftpClient.On("Remove", mock.Anything).Return(nil)
 
 	mockBlobHandler := &mocks.MockBlobHandler{}
@@ -250,7 +250,7 @@ func Test_copySingleFile_FileIsNotZipFile_LogThatFileIsSkipped(t *testing.T) {
 	fileBytes, _ := os.ReadFile(filePath)
 
 	mockSftpClient := new(MockSftpWrapper)
-	mockSftpClient.On("Open", mock.Anything).Return(bytes.NewReader(fileBytes), nil)
+	mockSftpClient.On("Open", mock.Anything).Return(io.NopCloser(bytes.NewReader(fileBytes)), nil)
 	mockSftpClient.On("Remove", mock.Anything).Return(nil)
 
 	mockBlobHandler := &mocks.MockBlobHandler{}
@@ -285,7 +285,7 @@ func Test_copySingleFile_FailsToUploadFile_LogsError(t *testing.T) {
 	fileBytes, _ := os.ReadFile(filePath)
 
 	mockSftpClient := new(MockSftpWrapper)
-	mockSftpClient.On("Open", mock.Anything).Return(bytes.NewReader(fileBytes), nil)
+	mockSftpClient.On("Open", mock.Anything).Return(io.NopCloser(bytes.NewReader(fileBytes)), nil)
 
 	mockBlobHandler := &mocks.MockBlobHandler{}
 	mockBlobHandler.On("UploadFile", mock.Anything, mock.Anything).Return(errors.New(utils.ErrorKey))
@@ -314,7 +314,7 @@ func Test_copySingleFile_FailsToUnzipFile_LogsError(t *testing.T) {
 	fileBytes, _ := os.ReadFile(filePath)
 
 	mockSftpClient := new(MockSftpWrapper)
-	mockSftpClient.On("Open", mock.Anything).Return(bytes.NewReader(fileBytes), nil)
+	mockSftpClient.On("Open", mock.Anything).Return(io.NopCloser(bytes.NewReader(fileBytes)), nil)
 	mockSftpClient.On("Remove", mock.Anything).Return(nil)
 
 	mockZipHandler := &MockZipHandler{}
@@ -346,7 +346,7 @@ func Test_copySingleFile_FailsToDeleteFileFromSFTPServer_LogsErrorAndReturn(t *t
 	fileBytes, _ := os.ReadFile(filePath)
 
 	mockSftpClient := new(MockSftpWrapper)
-	mockSftpClient.On("Open", mock.Anything).Return(bytes.NewReader(fileBytes), nil)
+	mockSftpClient.On("Open", mock.Anything).Return(io.NopCloser(bytes.NewReader(fileBytes)), nil)
 	mockSftpClient.On("Remove", mock.Anything).Return(errors.New("failed to remove file from sftp server"))
 
 	mockZipHandler := &MockZipHandler{}
@@ -378,7 +378,7 @@ func Test_copySingleFile_DeletesFileFromSFTPServer(t *testing.T) {
 	fileBytes, _ := os.ReadFile(filePath)
 
 	mockSftpClient := new(MockSftpWrapper)
-	mockSftpClient.On("Open", mock.Anything).Return(bytes.NewReader(fileBytes), nil)
+	mockSftpClient.On("Open", mock.Anything).Return(io.NopCloser(bytes.NewReader(fileBytes)), nil)
 	mockSftpClient.On("Remove", mock.Anything).Return(nil)
 
 	mockZipHandler := &MockZipHandler{}

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -224,7 +224,7 @@ func Test_copySingleFile_FailsToReadFile_LogsError(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(buffer, nil)))
 
 	mockSftpClient := new(MockSftpWrapper)
-	mockSftpClient.On("Open", mock.Anything).Return(ReadCloserThatErrors{Error: errors.New(utils.ErrorKey)}, nil)
+	mockSftpClient.On("Open", mock.Anything).Return(ReadCloserThatErrors{ReadError: errors.New(utils.ErrorKey)}, nil)
 
 	fileDirectory := filepath.Join("..", "..", "mock_data")
 	filePath := filepath.Join(fileDirectory, "copy_file_test.txt.zip")
@@ -245,7 +245,7 @@ func Test_copySingleFile_FailsToCloseFile_LogsError(t *testing.T) {
 	slog.SetDefault(slog.New(slog.NewTextHandler(buffer, nil)))
 
 	mockSftpClient := new(MockSftpWrapper)
-	mockSftpClient.On("Open", mock.Anything).Return(ReadCloserThatErrors{Error: io.EOF, CloseError: errors.New(utils.ErrorKey)}, nil)
+	mockSftpClient.On("Open", mock.Anything).Return(ReadCloserThatErrors{ReadError: io.EOF, CloseError: errors.New(utils.ErrorKey)}, nil)
 
 	fileDirectory := filepath.Join("..", "..", "mock_data")
 	filePath := filepath.Join(fileDirectory, "copy_file_test.txt.zip")
@@ -477,12 +477,12 @@ func (receiver *MockZipHandler) UploadErrorList(zipFilePath string, errorList []
 }
 
 type ReadCloserThatErrors struct {
-	Error      error
+	ReadError  error
 	CloseError error
 }
 
 func (r ReadCloserThatErrors) Read(p []byte) (int, error) {
-	return 0, r.Error
+	return 0, r.ReadError
 }
 
 func (r ReadCloserThatErrors) Close() error {

--- a/src/sftp/pkg_sftp.go
+++ b/src/sftp/pkg_sftp.go
@@ -1,11 +1,9 @@
 package sftp
 
 import (
-	"github.com/CDCgov/reportstream-sftp-ingestion/utils"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	"io"
-	"log/slog"
 	"os"
 )
 
@@ -26,7 +24,7 @@ func (p PkgSftpImplementation) ReadDir(path string) ([]os.FileInfo, error) {
 	return p.client.ReadDir(path)
 }
 
-func (p PkgSftpImplementation) Open(path string) (io.Reader, error) {
+func (p PkgSftpImplementation) Open(path string) (io.ReadCloser, error) {
 	file, err := p.client.Open(path)
 	if err != nil {
 		return nil, err
@@ -40,33 +38,33 @@ func (p PkgSftpImplementation) Close() error {
 }
 
 func (p PkgSftpImplementation) Remove(path string) error {
-	cwd, err := p.client.Getwd()
-	if err != nil {
-		slog.Error("Failed to get current working directory", slog.Any(utils.ErrorKey, err))
-	}
-
-	slog.Info("current working directory", slog.Any("cwd", cwd))
-
-	stat, err := p.client.Stat(path)
-	if err != nil {
-		slog.Error("Failed to stat file", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, path))
-	}
-
-	slog.Info("file name", slog.String(utils.FileNameKey, stat.Name()))
-
-	realPath, err := p.client.RealPath(path)
-	if err != nil {
-		slog.Error("Failed to realpath the path", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, path))
-	}
-
-	slog.Info("real path", slog.String(utils.FileNameKey, realPath))
-
-	err = p.client.Remove(stat.Name())
-	if err != nil {
-		slog.Error("First tried to remove with just the name", slog.String(utils.FileNameKey, stat.Name()), slog.Any(utils.ErrorKey, err))
-	} else {
-		slog.Info("The simple remove worked!")
-	}
+	//cwd, err := p.client.Getwd()
+	//if err != nil {
+	//	slog.Error("Failed to get current working directory", slog.Any(utils.ErrorKey, err))
+	//}
+	//
+	//slog.Info("current working directory", slog.Any("cwd", cwd))
+	//
+	//stat, err := p.client.Stat(path)
+	//if err != nil {
+	//	slog.Error("Failed to stat file", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, path))
+	//}
+	//
+	//slog.Info("file name", slog.String(utils.FileNameKey, stat.Name()))
+	//
+	//realPath, err := p.client.RealPath(path)
+	//if err != nil {
+	//	slog.Error("Failed to realpath the path", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, path))
+	//}
+	//
+	//slog.Info("real path", slog.String(utils.FileNameKey, realPath))
+	//
+	//err = p.client.Remove(stat.Name())
+	//if err != nil {
+	//	slog.Error("First tried to remove with just the name", slog.String(utils.FileNameKey, stat.Name()), slog.Any(utils.ErrorKey, err))
+	//} else {
+	//	slog.Info("The simple remove worked!")
+	//}
 
 	return p.client.Remove(path)
 }

--- a/src/sftp/pkg_sftp.go
+++ b/src/sftp/pkg_sftp.go
@@ -1,9 +1,11 @@
 package sftp
 
 import (
+	"github.com/CDCgov/reportstream-sftp-ingestion/utils"
 	"github.com/pkg/sftp"
 	"golang.org/x/crypto/ssh"
 	"io"
+	"log/slog"
 	"os"
 )
 
@@ -38,5 +40,26 @@ func (p PkgSftpImplementation) Close() error {
 }
 
 func (p PkgSftpImplementation) Remove(path string) error {
+	cwd, err := p.client.Getwd()
+	if err != nil {
+		slog.Error("Failed to get current working directory", slog.Any(utils.ErrorKey, err))
+	}
+
+	slog.Info("current working directory", slog.Any("cwd", cwd))
+
+	stat, err := p.client.Stat(path)
+	if err != nil {
+		slog.Error("Failed to stat file", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, path))
+	}
+
+	slog.Info("file name", slog.String(utils.FileNameKey, stat.Name()))
+
+	realPath, err := p.client.RealPath(path)
+	if err != nil {
+		slog.Error("Failed to realpath the path", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, path))
+	}
+
+	slog.Info("real path", slog.String(utils.FileNameKey, realPath))
+
 	return p.client.Remove(path)
 }

--- a/src/sftp/pkg_sftp.go
+++ b/src/sftp/pkg_sftp.go
@@ -38,33 +38,5 @@ func (p PkgSftpImplementation) Close() error {
 }
 
 func (p PkgSftpImplementation) Remove(path string) error {
-	//cwd, err := p.client.Getwd()
-	//if err != nil {
-	//	slog.Error("Failed to get current working directory", slog.Any(utils.ErrorKey, err))
-	//}
-	//
-	//slog.Info("current working directory", slog.Any("cwd", cwd))
-	//
-	//stat, err := p.client.Stat(path)
-	//if err != nil {
-	//	slog.Error("Failed to stat file", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, path))
-	//}
-	//
-	//slog.Info("file name", slog.String(utils.FileNameKey, stat.Name()))
-	//
-	//realPath, err := p.client.RealPath(path)
-	//if err != nil {
-	//	slog.Error("Failed to realpath the path", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, path))
-	//}
-	//
-	//slog.Info("real path", slog.String(utils.FileNameKey, realPath))
-	//
-	//err = p.client.Remove(stat.Name())
-	//if err != nil {
-	//	slog.Error("First tried to remove with just the name", slog.String(utils.FileNameKey, stat.Name()), slog.Any(utils.ErrorKey, err))
-	//} else {
-	//	slog.Info("The simple remove worked!")
-	//}
-
 	return p.client.Remove(path)
 }

--- a/src/sftp/pkg_sftp.go
+++ b/src/sftp/pkg_sftp.go
@@ -61,5 +61,12 @@ func (p PkgSftpImplementation) Remove(path string) error {
 
 	slog.Info("real path", slog.String(utils.FileNameKey, realPath))
 
+	err = p.client.Remove(stat.Name())
+	if err != nil {
+		slog.Error("First tried to remove with just the name", slog.String(utils.FileNameKey, stat.Name()), slog.Any(utils.ErrorKey, err))
+	} else {
+		slog.Info("The simple remove worked!")
+	}
+
 	return p.client.Remove(path)
 }

--- a/src/sftp/wrapper.go
+++ b/src/sftp/wrapper.go
@@ -7,7 +7,7 @@ import (
 
 type SftpWrapper interface {
 	ReadDir(path string) ([]os.FileInfo, error)
-	Open(path string) (io.Reader, error)
+	Open(path string) (io.ReadCloser, error)
 	Close() error
 	Remove(path string) error
 }

--- a/src/zip/zip.go
+++ b/src/zip/zip.go
@@ -80,7 +80,7 @@ func (zipHandler ZipHandler) Unzip(zipFilePath string) error {
 
 	// loop over contents
 	for _, f := range zipReader.File {
-		errorList = zipHandler.ExtractAndUploadSingleFile(f, zipPassword, errorList)
+		errorList = zipHandler.ExtractAndUploadSingleFile(f, zipPassword, zipFilePath, errorList)
 	}
 	// Upload error info if any
 	err = zipHandler.UploadErrorList(zipFilePath, errorList, err)
@@ -91,18 +91,18 @@ func (zipHandler ZipHandler) Unzip(zipFilePath string) error {
 	return nil
 }
 
-func (zipHandler ZipHandler) ExtractAndUploadSingleFile(f *zip.File, zipPassword string, errorList []FileError) []FileError {
-	slog.Info("preparing to process file", slog.String(utils.FileNameKey, f.Name))
+func (zipHandler ZipHandler) ExtractAndUploadSingleFile(f *zip.File, zipPassword string, zipFilePath string, errorList []FileError) []FileError {
+	slog.Info("Extracting file", slog.String(utils.FileNameKey, f.Name), slog.String("zipFilePath", zipFilePath))
 
 	// TODO - should we warn or error if not encrypted? This would vary per customer
 	if f.IsEncrypted() {
-		slog.Info("setting password for file", slog.String(utils.FileNameKey, f.Name))
+		slog.Info("setting password for file", slog.String(utils.FileNameKey, f.Name), slog.String("zipFilePath", zipFilePath))
 		f.SetPassword(zipPassword)
 	}
 
 	fileReader, err := f.Open()
 	if err != nil {
-		slog.Error("Failed to open file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to open message file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err), slog.String("zipFilePath", zipFilePath))
 		errorList = append(errorList, FileError{Filename: f.Name, ErrorMessage: err.Error()})
 		return errorList
 	}
@@ -110,7 +110,7 @@ func (zipHandler ZipHandler) ExtractAndUploadSingleFile(f *zip.File, zipPassword
 
 	buf, err := io.ReadAll(fileReader)
 	if err != nil {
-		slog.Error("Failed to read file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to read message file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err), slog.String("zipFilePath", zipFilePath))
 		errorList = append(errorList, FileError{Filename: f.Name, ErrorMessage: err.Error()})
 		return errorList
 	}
@@ -118,11 +118,11 @@ func (zipHandler ZipHandler) ExtractAndUploadSingleFile(f *zip.File, zipPassword
 	err = zipHandler.blobHandler.UploadFile(buf, filepath.Join(utils.MessageStartingFolderPath, f.FileInfo().Name()))
 
 	if err != nil {
-		slog.Error("Failed to upload file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err))
+		slog.Error("Failed to upload message file", slog.String(utils.FileNameKey, f.Name), slog.Any(utils.ErrorKey, err), slog.String("zipFilePath", zipFilePath))
 		errorList = append(errorList, FileError{Filename: f.Name, ErrorMessage: err.Error()})
 		return errorList
 	}
-	slog.Info("uploaded file to blob for import", slog.String(utils.FileNameKey, f.Name))
+	slog.Info("uploaded file to blob for import", slog.String(utils.FileNameKey, f.Name), slog.String("zipFilePath", zipFilePath))
 	return errorList
 }
 
@@ -136,7 +136,7 @@ func (zipHandler ZipHandler) UploadErrorList(zipFilePath string, errorList []Fil
 
 		err = zipHandler.blobHandler.UploadFile([]byte(fileContents), filepath.Join(utils.FailureFolder, zipFilePath+".txt"))
 		if err != nil {
-			slog.Error("Failed to upload failure file", slog.Any(utils.ErrorKey, err))
+			slog.Error("Failed to upload failure file", slog.Any(utils.ErrorKey, err), slog.String("zipFilePath", zipFilePath))
 			return err
 		}
 	}

--- a/src/zip/zip.go
+++ b/src/zip/zip.go
@@ -20,7 +20,7 @@ type ZipHandler struct {
 
 type ZipHandlerInterface interface {
 	Unzip(zipFilePath string) error
-	ExtractAndUploadSingleFile(f *zip.File, zipPassword string, errorList []FileError) []FileError
+	ExtractAndUploadSingleFile(f *zip.File, zipPassword string, zipFilePath string, errorList []FileError) []FileError
 	UploadErrorList(zipFilePath string, errorList []FileError, err error) error
 }
 

--- a/src/zip/zip_test.go
+++ b/src/zip/zip_test.go
@@ -43,8 +43,8 @@ func Test_Unzip_FileIsPasswordProtected_UnzipsSuccessfully(t *testing.T) {
 
 	err = zipHandler.Unzip("cheezburger")
 
-	assert.Contains(t, buffer.String(), "setting password")
-	assert.Contains(t, buffer.String(), "preparing to process file")
+	assert.Contains(t, buffer.String(), "setting password for file")
+	assert.Contains(t, buffer.String(), "Extracting file")
 	assert.NoError(t, err)
 }
 
@@ -78,8 +78,8 @@ func Test_Unzip_FileIsNotProtected_UnzipsSuccessfully(t *testing.T) {
 
 	err = zipHandler.Unzip("cheezburger")
 
-	assert.NotContains(t, buffer.String(), "setting password")
-	assert.Contains(t, buffer.String(), "preparing to process file")
+	assert.NotContains(t, buffer.String(), "setting password for file")
+	assert.Contains(t, buffer.String(), "Extracting file")
 	assert.NoError(t, err)
 }
 
@@ -102,8 +102,8 @@ func Test_Unzip_UnableToGetPassword_ReturnsError(t *testing.T) {
 
 	err := zipHandler.Unzip("cheezburger")
 
-	assert.NotContains(t, buffer.String(), "setting password")
-	assert.NotContains(t, buffer.String(), "preparing to process file")
+	assert.NotContains(t, buffer.String(), "setting password for file")
+	assert.NotContains(t, buffer.String(), "Extracting file")
 	assert.Contains(t, buffer.String(), "Unable to get zip password")
 	assert.Error(t, err)
 }
@@ -167,9 +167,9 @@ func Test_Unzip_FilePasswordIsWrong_UploadsErrorDocument(t *testing.T) {
 	err = zipHandler.Unzip("cheezburger.zip")
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, "failure/cheezburger.zip.txt")
-	assert.Contains(t, buffer.String(), "setting password")
-	assert.Contains(t, buffer.String(), "preparing to process file")
-	assert.Contains(t, buffer.String(), "Failed to read file")
+	assert.Contains(t, buffer.String(), "setting password for file")
+	assert.Contains(t, buffer.String(), "Extracting file")
+	assert.Contains(t, buffer.String(), "Failed to read message file")
 	assert.NoError(t, err)
 }
 
@@ -204,8 +204,8 @@ func Test_Unzip_UnzippedFileCannotBeUploaded_ReturnsError(t *testing.T) {
 	err = zipHandler.Unzip("cheezburger")
 
 	assert.Contains(t, buffer.String(), "setting password")
-	assert.Contains(t, buffer.String(), "preparing to process file")
-	assert.Contains(t, buffer.String(), "Failed to upload file")
+	assert.Contains(t, buffer.String(), "Extracting file")
+	assert.Contains(t, buffer.String(), "Failed to upload message file")
 	assert.Error(t, err)
 }
 


### PR DESCRIPTION
## Description

For the CA SFTP server, we need to _close_ the file after reading it all.  If you don't, then we can't delete it.

This is adding a few logging improvements.  This also comments out the private key usage to authenticate to the server (because CA doesn't use it yet).

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1077

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)

**Note**: You may remove items that are not applicable
