### PR TITLE
set https_only to true for fortify requirement

### DIFF
--- a/operations/template/functions.tf
+++ b/operations/template/functions.tf
@@ -6,6 +6,7 @@ resource "azurerm_linux_function_app" "polling_trigger_function_app" {
   service_plan_id            = azurerm_service_plan.plan.id
   storage_account_name       = azurerm_storage_account.storage.name
   storage_account_access_key = azurerm_storage_account.storage.primary_access_key
+  https_only                 = true
 
   app_settings = {
     AZURE_STORAGE_CONNECTION_STRING = azurerm_storage_account.storage.primary_connection_string


### PR DESCRIPTION
## Description
Set `https_only` to `true` to meet a fortify requirement

This `Azure Terraform Misconfiguration: Insecure Function App Transport` error:
![image](https://github.com/user-attachments/assets/80dc4573-a744-4a08-a1cd-54a7f489c0e1)

goes away after making the change in this PR:
![image](https://github.com/user-attachments/assets/04a2f087-cb26-48f1-9dff-09eb09ba0fa3)

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1236

