### PR TITLE
Fixing version issue inside of go.mod file

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,8 @@
 module github.com/CDCgov/reportstream-sftp-ingestion
 
-go 1.22.6
+go 1.23
+
+toolchain go1.23.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/CDCgov/reportstream-sftp-ingestion
 
-go 1.22
+go 1.22.6
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0


### PR DESCRIPTION
## Description

Git scans were complaining that our version of go requires 3 tiers in the version number

