### PR TITLE
1080: Update Read and send errors

### DIFF
--- a/src/senders/report_stream_sender.go
+++ b/src/senders/report_stream_sender.go
@@ -152,8 +152,9 @@ func (sender Sender) SendMessage(message []byte) (string, error) {
 		slog.Info("status", slog.Any("code", res.StatusCode), slog.String("status", res.Status))
 		// The response body from ReportStream may include additional error details. See examples in json_responses.go
 		slog.Info("response body", slog.String("responseBodyBytes", string(responseBodyBytes)))
-		// TODO - return a magic word when the status code is >=400 and < 500. In read_and_send, move to failure folder on magic word
-		//		Also maybe make the info logs above into a combined error?
+		if res.StatusCode >= 400 && res.StatusCode < 500 {
+			return "", errors.New(utils.ReportStreamNonTransientFailure)
+		}
 		return "", errors.New(res.Status)
 	}
 

--- a/src/senders/report_stream_sender.go
+++ b/src/senders/report_stream_sender.go
@@ -152,6 +152,8 @@ func (sender Sender) SendMessage(message []byte) (string, error) {
 		slog.Info("status", slog.Any("code", res.StatusCode), slog.String("status", res.Status))
 		// The response body from ReportStream may include additional error details. See examples in json_responses.go
 		slog.Info("response body", slog.String("responseBodyBytes", string(responseBodyBytes)))
+		// TODO - return a magic word when the status code is >=400 and < 500. In read_and_send, move to failure folder on magic word
+		//		Also maybe make the info logs above into a combined error?
 		return "", errors.New(res.Status)
 	}
 

--- a/src/senders/report_stream_sender_test.go
+++ b/src/senders/report_stream_sender_test.go
@@ -56,14 +56,11 @@ func (suite *SenderTestSuite) Test_NewSender_EnvIsEmpty_ReturnsSenderWithLocalCr
 func (suite *SenderTestSuite) Test_GenerateJWT_ReturnsJWT() {
 
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 	jwt, err := sender.generateJwt()
 
@@ -74,7 +71,6 @@ func (suite *SenderTestSuite) Test_GenerateJWT_ReturnsJWT() {
 func (suite *SenderTestSuite) Test_GenerateJWT_UnableToGetPrivateKey_ReturnsError() {
 
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
@@ -87,14 +83,11 @@ func (suite *SenderTestSuite) Test_GenerateJWT_UnableToGetPrivateKey_ReturnsErro
 
 func (suite *SenderTestSuite) Test_getToken_ReturnsAccessToken() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	// Set up a test server for ReportStream
@@ -122,7 +115,6 @@ func (suite *SenderTestSuite) Test_getToken_ReturnsAccessToken() {
 
 func (suite *SenderTestSuite) Test_getToken_UnableToGenerateJWT_ReturnsError() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
@@ -137,14 +129,11 @@ func (suite *SenderTestSuite) Test_getToken_UnableToGenerateJWT_ReturnsError() {
 func (suite *SenderTestSuite) Test_getToken_UnableToCallTokenEndpoint_ReturnsError() {
 	os.Setenv("REPORT_STREAM_URL_PREFIX", "this is not a good URL")
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	token, err := sender.getToken()
@@ -155,14 +144,11 @@ func (suite *SenderTestSuite) Test_getToken_UnableToCallTokenEndpoint_ReturnsErr
 
 func (suite *SenderTestSuite) Test_getToken_ReportStreamResponseStatusIsInvalid_ReturnsError() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	// Set up a test server for ReportStream
@@ -190,14 +176,11 @@ func (suite *SenderTestSuite) Test_getToken_ReportStreamResponseStatusIsInvalid_
 
 func (suite *SenderTestSuite) Test_getToken_UnableToMarshallResponseBody_ReturnsError() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	// Set up a test server for ReportStream
@@ -221,14 +204,11 @@ func (suite *SenderTestSuite) Test_getToken_UnableToMarshallResponseBody_Returns
 
 func (suite *SenderTestSuite) Test_SendMessage_MessageSentToReportStream_ReturnsReportId() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	// Set up a test server for ReportStream
@@ -288,14 +268,11 @@ func (suite *SenderTestSuite) Test_SendMessage_MessageSentToReportStream_Returns
 
 func (suite *SenderTestSuite) Test_SendMessage_UnableToGetToken_ReturnsError() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, errors.New(utils.ErrorKey))
 
 	message, _ := os.ReadFile(filepath.Join("..", "..", "mock_data", "order_message.hl7"))
@@ -309,14 +286,11 @@ func (suite *SenderTestSuite) Test_SendMessage_UnableToGetToken_ReturnsError() {
 
 func (suite *SenderTestSuite) Test_SendMessage_UnableToCallTokenEndpoint_ReturnsError() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	// Set up a test server for ReportStream
@@ -351,14 +325,11 @@ func (suite *SenderTestSuite) Test_SendMessage_UnableToCallTokenEndpoint_Returns
 
 func (suite *SenderTestSuite) Test_SendMessage_StatusCodeIsAbove300_ReturnsError() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	// Set up a test server for ReportStream
@@ -420,14 +391,11 @@ func (suite *SenderTestSuite) Test_SendMessage_StatusCodeIsAbove300_ReturnsError
 
 func (suite *SenderTestSuite) Test_SendMessage_StatusCodeIs400_ReturnsNonTransientError() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	// Set up a test server for ReportStream
@@ -558,14 +526,11 @@ func (suite *SenderTestSuite) Test_SendMessage_StatusCodeIsAbove499_ReturnsError
 
 func (suite *SenderTestSuite) Test_SendMessage_UnableToParseResponseBody_ReturnsError() {
 	sender, err := NewSender()
-	assert.NoError(suite.T(), err)
 
 	mockCredentialGetter := new(mocks.MockCredentialGetter)
 	sender.credentialGetter = mockCredentialGetter
 
 	testKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	assert.NoError(suite.T(), err)
-
 	mockCredentialGetter.On("GetPrivateKey", "key").Return(testKey, nil)
 
 	// Set up a test server for ReportStream

--- a/src/usecases/read_and_send.go
+++ b/src/usecases/read_and_send.go
@@ -61,7 +61,7 @@ func (receiver *ReadAndSendUsecase) ReadAndSend(sourceUrl string) error {
 	if err != nil {
 		slog.Error("Failed to send the file to ReportStream", slog.Any(utils.ErrorKey, err), slog.String("sourceUrl", sourceUrl))
 
-		// As of August 2024, we trigger on anything error >= 400 and < 500 and move to the `failure` folder.
+		// As of August 2024, we trigger on any http status code >= 400 and < 500 and move to the `failure` folder.
 		// Returning `nil` will let queue.go delete the queue message so that it will stop retrying
 		// We're treating all other errors as unexpected (and possibly transient) for now
 		if strings.Contains(err.Error(), utils.ReportStreamNonTransientFailure) {

--- a/src/usecases/read_and_send.go
+++ b/src/usecases/read_and_send.go
@@ -61,8 +61,8 @@ func (receiver *ReadAndSendUsecase) ReadAndSend(sourceUrl string) error {
 	if err != nil {
 		slog.Error("Failed to send the file to ReportStream", slog.Any(utils.ErrorKey, err), slog.String("sourceUrl", sourceUrl))
 
-		// As of June 2024, only the 400 response triggers a move to the `failure` folder. Returning `nil` will let
-		// queue.go delete the queue message so that it will stop retrying
+		// As of August 2024, we trigger on anything error >= 400 and < 500 and move to the `failure` folder.
+		// Returning `nil` will let queue.go delete the queue message so that it will stop retrying
 		// We're treating all other errors as unexpected (and possibly transient) for now
 		if strings.Contains(err.Error(), utils.ReportStreamNonTransientFailure) {
 			receiver.moveFile(sourceUrl, utils.FailureFolder)

--- a/src/usecases/read_and_send_test.go
+++ b/src/usecases/read_and_send_test.go
@@ -21,13 +21,13 @@ func Test_ReadAndSend_FailsToReadBlob_ReturnsError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Test_ReadAndSend_400FromReportStream_MovesFileToFailureFolder(t *testing.T) {
+func Test_ReadAndSend_NonTransientFailureFromReportStream_MovesFileToFailureFolder(t *testing.T) {
 	mockBlobHandler := &mocks.MockBlobHandler{}
 	mockBlobHandler.On("FetchFile", utils.SourceUrl).Return([]byte("The DogCow went Moof!"), nil)
 	mockBlobHandler.On("MoveFile", utils.SourceUrl, utils.FailureSourceUrl).Return(nil)
 
 	mockMessageSender := &MockMessageSender{}
-	mockMessageSender.On("SendMessage", mock.Anything).Return("", errors.New("400 Bad Request"))
+	mockMessageSender.On("SendMessage", mock.Anything).Return("", errors.New(utils.ReportStreamNonTransientFailure))
 
 	usecase := ReadAndSendUsecase{blobHandler: mockBlobHandler, messageSender: mockMessageSender}
 

--- a/src/utils/constants.go
+++ b/src/utils/constants.go
@@ -19,7 +19,7 @@ const FailureFolder = "failure"
 const UnzipFolder = "unzip"
 
 // In read_and_send, move files to the `FailureFolder` when we get the below response from ReportStream
-const ReportStreamNonTransientFailure = "400"
+const ReportStreamNonTransientFailure = "reportStreamNonTransientFailure"
 
 // Use this when logging an error.
 // E.g. `slog.Warn("Failed to construct the ReportStream senders", slog.Any(utils.ErrorKey, err))`


### PR DESCRIPTION
## Description

Updates Read and Send Errors to move all Non Transient errors(error codes between 400 and 499) to the failure folder.

## Issue

[Issue 1080](https://github.com/CDCgov/trusted-intermediary/issues/1080)

## Checklist

- [ ] I have added tests to cover my changes
- [ ] I have added logging where useful (with appropriate log level)
- [ ] I have added GoDocs where required
- [ ] I have updated the documentation accordingly

**Note**: You may remove items that are not applicable
