### PR TITLE
Send function app logs to log analytics workspace

### DIFF
--- a/codeCoverageThresholdCheck.sh
+++ b/codeCoverageThresholdCheck.sh
@@ -3,7 +3,7 @@ set -e
 
 pushd ./src/ || exit
 
-THRESHOLD=65
+THRESHOLD=80
 COVERAGE=$(go tool cover -func ./coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+')
 
 echo "Code coverage is $COVERAGE%, and the threshold is $THRESHOLD%"

--- a/operations/template/logs.tf
+++ b/operations/template/logs.tf
@@ -55,3 +55,15 @@ resource "azurerm_monitor_diagnostic_setting" "app_to_logs" {
     category = "AppServicePlatformLogs"
   }
 }
+
+resource "azurerm_monitor_diagnostic_setting" "functionapp_to_logs" {
+  name                       = "rs-sftp-function-app-to-logs-${var.environment}"
+  target_resource_id         = azurerm_linux_function_app.polling_trigger_function_app.id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.logs_workspace.id
+
+  log_analytics_destination_type = "Dedicated"
+
+  enabled_log {
+    category = "FunctionAppLogs"
+  }
+}


### PR DESCRIPTION
## Description
Currently we can't read the Azure Function App logs easily. This change sends them to the log analytics workspace, like we already do for the app service

We tested this in the `internal` environment and were able to access logs:
![image](https://github.com/user-attachments/assets/524c22e4-2efa-4171-8e89-0e7c891b059c)
 

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1080

