### PR TITLE
Low Privilege User for Compiling and Running the Application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,19 +4,26 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 
-RUN apt update && apt install -y --no-install-recommends ca-certificates && apt clean
+RUN apt update && apt upgrade && apt clean
 
-WORKDIR /opt/build/
+RUN useradd myLowPrivilegeUser
+USER myLowPrivilegeUser
 
-COPY ./ ./
+WORKDIR /home/myLowPrivilegeUser/app/
+
+COPY --chown=myLowPrivilegeUser ./ ./
 
 RUN make compile
 
 
-FROM scratch
+FROM alpine
 
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /opt/build/reportstream-sftp-ingestion /usr/local/bin/reportstream-sftp-ingestion
+RUN apk update && apk upgrade && apk add ca-certificates && rm -rf /var/cache/apk/*
+
+COPY --from=builder /home/myLowPriviledgeUser/app/reportstream-sftp-ingestion /usr/local/bin/reportstream-sftp-ingestion
+
+RUN adduser -S myLowPrivilegeUser
+USER myLowPrivilegeUser
 
 ENTRYPOINT ["/usr/local/bin/reportstream-sftp-ingestion"]
 


### PR DESCRIPTION
## Description

Updated our `Dockerfile` to use a lower privilege user for compiling and running the application.  After discussing with the team, we decided to pivot to Alpine Linux for our running Docker image instead of `sratch` because we had to be a bit hacky with adding a lower privilege user in the `sratch` image that required copying `/etc/passwd` and `/etc/group` from the building image.  The size difference is minimal: 12.7 MB for the `sratch` base image version and 20.79 MB for the Alpine Linux base image version.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1211