### PR TITLE
Update dockerfile to auto yes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV CGO_ENABLED=0
 
 RUN apt update && apt upgrade && apt clean
 
+
 RUN useradd myLowPrivilegeUser
 USER myLowPrivilegeUser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 
-RUN apt update -y && apt upgrade -y && apt clean -y
+RUN apt-get update -y && apt-get upgrade -y && apt-get clean -y
 
 RUN useradd myLowPrivilegeUser
 USER myLowPrivilegeUser

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,7 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 ENV CGO_ENABLED=0
 
-RUN apt update && apt upgrade && apt clean
-
+RUN apt update -y && apt upgrade -y && apt clean -y
 
 RUN useradd myLowPrivilegeUser
 USER myLowPrivilegeUser


### PR DESCRIPTION
## Description
`apt` doesn't have a stable CLI and [started requiring an interaction (which is not possible during a script), causing deploys to fail](https://github.com/CDCgov/reportstream-sftp-ingestion/actions/runs/10580887694/job/29318333735#step:9:323). This PR updates the dockerfile to auto-yes when prompted, and to use `apt-get` instead of `apt` which is more stable

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1211

