### PR TITLE
Keep pre-live deployment slot healthy

### DIFF
--- a/operations/template/logs.tf
+++ b/operations/template/logs.tf
@@ -25,7 +25,7 @@ resource "azurerm_log_analytics_query_pack" "application_logs_pack" {
   }
 }
 
-resource "azurerm_log_analytics_query_pack_query" "example" {
+resource "azurerm_log_analytics_query_pack_query" "structured_application_logs" {
   display_name = "RS SFTP's Raw Application Logs"
   description  = "View all RS SFTP's application logs in a structured format"
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -18,9 +18,11 @@ func main() {
 
 	go setupHealthCheck()
 
-	// Set up the polling message handler and queue listener
 	setUpQueues()
 
+	// This loop keeps the app alive. This lets the pre-live deployment slot remain healthy
+	// even though it's configured without queues, which means we can quickly swap slots
+	// if needed without having to redeploy
 	for {
 		t := time.Now()
 		slog.Info(t.Format("2006-01-02T15:04:05Z07:00"))
@@ -29,6 +31,7 @@ func main() {
 }
 
 func setUpQueues() {
+	// Set up the polling message handler and queue listener
 	pollingMessageHandler := orchestration.PollingMessageHandler{}
 
 	pollingQueueHandler, err := orchestration.NewQueueHandler(pollingMessageHandler, "polling-trigger")

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 )
 
 func main() {
@@ -18,6 +19,16 @@ func main() {
 	go setupHealthCheck()
 
 	// Set up the polling message handler and queue listener
+	setUpQueues()
+
+	for {
+		t := time.Now()
+		slog.Info(t.Format("2006-01-02T15:04:05Z07:00"))
+		time.Sleep(10 * time.Minute)
+	}
+}
+
+func setUpQueues() {
 	pollingMessageHandler := orchestration.PollingMessageHandler{}
 
 	pollingQueueHandler, err := orchestration.NewQueueHandler(pollingMessageHandler, "polling-trigger")
@@ -40,8 +51,10 @@ func main() {
 		slog.Warn("Failed to create importQueueHandler", slog.Any(utils.ErrorKey, err))
 		return
 	}
-	// This ListenToQueue is not split into a separate Go Routine since it is the core driver of the application
-	importQueueHandler.ListenToQueue()
+
+	go func() {
+		importQueueHandler.ListenToQueue()
+	}()
 }
 
 func setupLogging() {


### PR DESCRIPTION
## Description
The ingestion service app is driving off queue readers. When we added the pre-live deployment slot, we needed the pre-live instance to _not_ consume queue messages. However, if the application exits the deployment becomes unhealthy, leaving us unable to swap slots post-deploy for a rollback. 

This PR includes a minor refactor to move the queue setup into its own function, puts both queue listeners into their own go func instead of just one of them, and adds a for loop to keep the app alive regardless of whether queues are configured. It also renames a terraform resource

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1220
