### PR TITLE
Add terraform format to pre commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: terraform-format
         name: terraform-format
-        entry: bash -c 'terraform fmt -recursive || (echo ""; echo "!!Automatically running terraform format!!";terraform fmt -recursive -write && git status)'
+        entry: bash -c 'terraform fmt -recursive -write'
         language: system
         types_or:
           - terraform

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,13 @@ repos:
         types_or:
           - go
         pass_filenames: false
+
+  - repo: local
+    hooks:
+      - id: terraform-format
+        name: terraform-format
+        entry: bash -c 'terraform fmt -recursive || (echo ""; echo "!!Automatically running terraform format!!";terraform fmt -recursive -write && git status)'
+        language: system
+        types_or:
+          - terraform
+        pass_filenames: false


### PR DESCRIPTION
## Description
This PR adds terraform format to pre-commit hooks because it's really irritating when PR checks fail just because of terraform formatting

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1291