### PR TITLE
Allow Deployment Slot to Pull from Container Registry

### DIFF
--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -33,6 +33,12 @@ resource "azurerm_role_assignment" "allow_app_to_pull_from_registry" {
   scope                = azurerm_container_registry.registry.id
 }
 
+resource "azurerm_role_assignment" "allow_app_slot_to_pull_from_registry" {
+  principal_id         = azurerm_linux_web_app_slot.pre_live.identity.0.principal_id
+  role_definition_name = "AcrPull"
+  scope                = azurerm_container_registry.registry.id
+}
+
 resource "azurerm_user_assigned_identity" "key_vault_identity" {
   resource_group_name = data.azurerm_resource_group.group.name
   location            = data.azurerm_resource_group.group.location
@@ -158,6 +164,8 @@ resource "azurerm_linux_web_app_slot" "pre_live" {
     health_check_eviction_time_in_min = 5
 
     scm_use_main_ip_restriction = local.cdc_domain_environment ? true : null
+
+    container_registry_use_managed_identity = true
 
     application_stack {
       docker_registry_url = "https://${azurerm_container_registry.registry.login_server}"


### PR DESCRIPTION
## Description

Sometimes our pre-live deployment slots would be unhealthy.  This will allow them to a) use their own managed identity to pull from the registry, and b) have permission to pull from the registry.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1220