### PR TITLE
Use CA PHL's ReportStream Sender

### DIFF
--- a/operations/template/app.tf
+++ b/operations/template/app.tf
@@ -128,7 +128,7 @@ resource "azurerm_linux_web_app" "sftp" {
     AZURE_STORAGE_CONNECTION_STRING = azurerm_storage_account.storage.primary_blob_connection_string
     REPORT_STREAM_URL_PREFIX        = "https://${local.rs_domain_prefix}prime.cdc.gov"
     AZURE_KEY_VAULT_URI             = azurerm_key_vault.key_storage.vault_uri
-    CA_PHL_CLIENT_NAME              = "flexion.simulated-lab"
+    CA_PHL_CLIENT_NAME              = "ca-phl.etor-nbs-results"
     QUEUE_MAX_DELIVERY_ATTEMPTS     = azurerm_eventgrid_system_topic_event_subscription.topic_sub.retry_policy.0.max_delivery_attempts # making the Azure container <-> queue retry count be in sync with the queue <-> application retry count..
   }
 

--- a/src/senders/report_stream_sender.go
+++ b/src/senders/report_stream_sender.go
@@ -77,7 +77,7 @@ func (sender Sender) getToken() (string, error) {
 	}
 
 	data := url.Values{
-		"scope":                 {"flexion.*.report"},
+		"scope":                 {"ca-phl.*.report"},
 		"grant_type":            {"client_credentials"},
 		"client_assertion_type": {"urn:ietf:params:oauth:client-assertion-type:jwt-bearer"},
 		"client_assertion":      {senderJwt},


### PR DESCRIPTION
## Description

Updated the ReportStream client name to actually be CA PHL's.  Also updated the scope of the ReportStream API call.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1153

## Checklist

- [x] Test in Internal.
- [x] Test in Dev.
