### PR TITLE
Use the Proper `prd` Environment Name in Terraform

### DIFF
--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -1,8 +1,8 @@
 locals {
   environment_to_rs_environment_prefix_mapping = {
-    dev  = "staging"
-    stg  = "staging"
-    prod = ""
+    dev = "staging"
+    stg = "staging"
+    prd = ""
   }
   selected_rs_environment_prefix = lookup(local.environment_to_rs_environment_prefix_mapping, var.environment, "staging")
   rs_domain_prefix               = "${local.selected_rs_environment_prefix}${length(local.selected_rs_environment_prefix) == 0 ? "" : "."}"


### PR DESCRIPTION
## Description

Our production environment was using the staging environment of ReportStream because our mapping between our environments and RS's environment was incorrect.  This has been fixed.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1153
