### PR TITLE
Change prd CRON to never run

### DIFF
--- a/operations/environments/prd/main.tf
+++ b/operations/environments/prd/main.tf
@@ -30,5 +30,5 @@ module "template" {
 
   environment = "prd"
   deployer_id = "f5feabe7-5d37-40ba-94f2-e5c0760b4561" //github app registration in Flexion Azure Entra
-  cron        = "0 30 9 * May Mon"
+  cron        = "* * * 30 Feb *"                       //run every second of February 30th, which never happens and is the equivalent of never running
 }


### PR DESCRIPTION
## Description

Change the production CRON expression to be February 30th which is the same as never running.  We will update this to the real schedule when CDPH allows us.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1153

## Checklist

Tested this here: https://ncrontab.swimburger.net/?expression=*+*+*+30+Feb+*
