### PR TITLE
Adding function timezones for partner specific settings.

### DIFF
--- a/operations/template/functions.tf
+++ b/operations/template/functions.tf
@@ -13,7 +13,7 @@ resource "azurerm_linux_function_app" "polling_trigger_function_app" {
     POLLING_TRIGGER_QUEUE_NAME      = azurerm_storage_queue.polling_trigger_queue.name
     CA_DPH_POLLING_CRON             = var.cron
 
-    WEBSITE_TIME_ZONE               = "America/Los_Angeles"
+    WEBSITE_TIME_ZONE = "America/Los_Angeles"
 
     # Makes the Github Action run significantly faster by not copying the node_modules
     WEBSITE_RUN_FROM_PACKAGE = 1

--- a/operations/template/functions.tf
+++ b/operations/template/functions.tf
@@ -13,6 +13,8 @@ resource "azurerm_linux_function_app" "polling_trigger_function_app" {
     POLLING_TRIGGER_QUEUE_NAME      = azurerm_storage_queue.polling_trigger_queue.name
     CA_DPH_POLLING_CRON             = var.cron
 
+    WEBSITE_TIME_ZONE               = "America/Los_Angeles"
+
     # Makes the Github Action run significantly faster by not copying the node_modules
     WEBSITE_RUN_FROM_PACKAGE = 1
   }


### PR DESCRIPTION
Adding timezone for the function trigger so that it is in the correct timezone

## Issue

We are currently not using timezones, we should use timezones based on the partners location for the function
[Timezone card](https://github.com/CDCgov/trusted-intermediary/issues/1338)



