### PR TITLE
Remove Non-Zip File from SFTP Sever 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - ./mock_credentials/ca-phl-sftp-user-credential-public-key-local:/home/ti_user/.ssh/keys/id_rsa.pub:ro
       - ./mock_credentials/ca-phl-sftp-host-private-key-local:/etc/ssh/ssh_host_rsa_key
       - ./localdata/sftp_server_require_publickey.sh:/etc/sftp.d/sftp_server_require_publickey.sh
-      - ./localdata/data/sftp:/home/ti_user/files
+      - ./localdata/data/sftp:/home/ti_user/files/DPH-Staging/HealthPartner-Staging/UCSD/OUTPUT
     ports:
       - "2223:22"
     networks:

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -358,7 +358,7 @@ func Test_copySingleFile_FailsToCloseFile_LogsError(t *testing.T) {
 	assert.Contains(t, buffer.String(), "Failed to close file after reading")
 }
 
-func Test_copySingleFile_FileIsNotZipFile_LogThatFileIsSkipped(t *testing.T) {
+func Test_copySingleFile_FileIsNotZipFile_DoesNotUnzipFile(t *testing.T) {
 	buffer, defaultLogger := utils.SetupLogger()
 	defer slog.SetDefault(defaultLogger)
 
@@ -382,12 +382,11 @@ func Test_copySingleFile_FileIsNotZipFile_LogThatFileIsSkipped(t *testing.T) {
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
 	mockSftpClient.AssertCalled(t, "Open", mock.Anything)
+	mockZipHandler.AssertNotCalled(t, "Unzip", mock.Anything)
+	mockSftpClient.AssertCalled(t, "Remove", mock.Anything)
 	assert.Contains(t, buffer.String(), "Considering file")
 	assert.NotContains(t, buffer.String(), "Skipping directory")
-	assert.NotContains(t, buffer.String(), "Failed to open file")
-	assert.NotContains(t, buffer.String(), "Failed to read file")
-	assert.NotContains(t, buffer.String(), "Failed to upload file")
-	assert.Contains(t, buffer.String(), "This is not a zip file so we won't unzip it before import")
+	assert.Contains(t, buffer.String(), "Successfully copied file and removed from SFTP server")
 }
 
 func Test_copySingleFile_FailsToUploadFile_LogsError(t *testing.T) {


### PR DESCRIPTION
Remove Non-Zip File from SFTP Sever 

## Description

Refactored copySingleFile to prevent early returning for a non-zip file when removing file from sftp server. Updated docker-compose to have consistent starting directory for sftp server. Tested locally to ensure that non-zip is ingested and deleted. 

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1337

## Checklist

- [x] I have added tests to cover my changes

**Note**: You may remove items that are not applicable
