### PR TITLE
Make the Logging Query Similar to TI's

### DIFF
--- a/operations/template/logs.tf
+++ b/operations/template/logs.tf
@@ -32,7 +32,7 @@ resource "azurerm_log_analytics_query_pack_query" "structured_application_logs" 
   query_pack_id = azurerm_log_analytics_query_pack.application_logs_pack.id
   categories    = ["applications"]
 
-  body = "AppServiceConsoleLogs | extend JsonResult = parse_json(ResultDescription) | project-away TimeGenerated, Level, ResultDescription, Host, Type, _ResourceId, OperationName, TenantId, SourceSystem | evaluate bag_unpack(JsonResult)"
+  body = "AppServiceConsoleLogs | project JsonResult = parse_json(ResultDescription) | evaluate bag_unpack(JsonResult) | project-reorder ['time'], level, msg"
 }
 
 resource "azurerm_monitor_diagnostic_setting" "app_to_logs" {


### PR DESCRIPTION
## Description

Changed the saved log query in the Azure Logs Analytics Workspace to be more inline with TI's.  This makes the query simpler, faster to execute, and always puts the timestamp first (even when there are logs from when a message being processed).

## Issue

_None_.