### PR TITLE
Add pipeline failure if functions are missing

### DIFF
--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -75,3 +75,16 @@ jobs:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
           package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
           publish-profile: ${{ steps.getPublishProfile.outputs.PUBLISH_PROFILE }}
+
+      - name: 'Retrieve Azure FunctionApp loaded Functions'
+        run: |
+          FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
+          echo "::add-mask::$FUNCTION_LIST"
+          echo "FUNCTION_LIST" >> $GITHUB_OUTPUT
+        id: getFunctionList
+
+      - name: 'Azure FunctionApp Check'
+        if: steps.getFunctionList.outputs.FUNCTION_LIST == ''
+        run: |
+          echo 'Azure FunctionApp Function is empty'
+          exit 1  

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,8 +79,7 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST = *"ResourceNotFound"* ]] \
-          then 
+          if [[ $FUNCTION_LIST = *"ResourceNotFound"* ]] then
             FAIL=true
           fi
           echo "$FAIL" >> $GITHUB_OUTPUT

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,10 +79,9 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST == *"ResourceNotFound"*]] then 
-            FAIL=true
+          if [[ $FUNCTION_LIST == *"ResourceNotFound"*]]; then \ 
+            FAIL=true \
           fi
-          echo "::add-mask::$FAIL"
           echo "$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -80,8 +80,8 @@ jobs:
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
           if [[ $FUNCTION_LIST = *"ResourceNotFound"* ]] \
-          then \ 
-            FAIL=true \
+          then 
+            FAIL=true
           fi
           echo "$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -82,6 +82,7 @@ jobs:
           if [[ $FUNCTION_LIST == *"ResourceNotFound"* ]]; then 
             FAIL=true 
           fi 
+          echo "$FAIL"
           echo "$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -78,4 +78,4 @@ jobs:
 
       - name: 'Validate that Azure FunctionApp loaded Functions'
         run: |
-          $(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
+          az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}"

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,7 +79,7 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST == *"ResourceNotFound"*]]; then 
+          if [[ $FUNCTION_LIST == *"ResourceNotFound"*]] then 
             FAIL=true
           fi
           echo "::add-mask::$FAIL"

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,10 +79,9 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST = *"ResourceNotFound"* ]] \
-          then \
-            FAIL=true \
-          fi \
+          if [[ $FUNCTION_LIST == *"ResourceNotFound"* ]]; then 
+            FAIL=true 
+          fi 
           echo "$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -78,17 +78,17 @@ jobs:
 
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
-          FAIL=false
+          FAIL="false"
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
           if [[ $FUNCTION_LIST == *"ResourceNotFound"* ]]; then 
-            FAIL=true 
+            FAIL="true" 
           fi 
           echo "$FAIL"
           echo "$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 
       - name: 'Azure FunctionApp Check'
-        if: steps.getFunctionList.outputs.FAIL == true
+        if: steps.getFunctionList.outputs.FAIL == 'true'
         run: |
           echo 'Azure FunctionApp Function is empty'
           exit 1  

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -82,8 +82,8 @@ jobs:
           if [[ $FUNCTION_LIST == *"ResourceNotFound"*]]; then 
             FAIL=true
           fi
-          echo "::add-mask::FAIL"
-          echo "FAIL" >> $GITHUB_OUTPUT
+          echo "::add-mask::$FAIL"
+          echo "$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 
       - name: 'Azure FunctionApp Check'

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -78,6 +78,7 @@ jobs:
 
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
+          FAIL=false
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
           if [[ $FUNCTION_LIST == *"ResourceNotFound"* ]]; then 
             FAIL=true 

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,7 +79,8 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST == *"ResourceNotFound"*]]; then \ 
+          if [[ $FUNCTION_LIST == *"ResourceNotFound"*]] \
+          then \ 
             FAIL=true \
           fi
           echo "$FAIL" >> $GITHUB_OUTPUT

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -76,19 +76,6 @@ jobs:
           package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
           publish-profile: ${{ steps.getPublishProfile.outputs.PUBLISH_PROFILE }}
 
-      - name: 'Retrieve Azure FunctionApp loaded Functions'
+      - name: 'Validate that Azure FunctionApp loaded Functions'
         run: |
-          FAIL="false"
-          FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}-2")
-          if [[ $FUNCTION_LIST == *"ResourceNotFound"* ]]; then 
-            FAIL="true" 
-          fi 
-          echo "$FAIL"
-          echo "FAIL=$FAIL" >> $GITHUB_OUTPUT
-        id: getFunctionList
-
-      - name: 'Azure FunctionApp Check'
-        if: steps.getFunctionList.outputs.FAIL == 'true'
-        run: |
-          echo 'Azure FunctionApp Function is empty'
-          exit 1  
+          $(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}-2")

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,12 +79,15 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          echo "::add-mask::$FUNCTION_LIST"
-          echo "FUNCTION_LIST" >> $GITHUB_OUTPUT
+          if [[ $FUNCTION_LIST == *"ResourceNotFound"*]]; then 
+            FAIL=true
+          fi
+          echo "::add-mask::FAIL"
+          echo "FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 
       - name: 'Azure FunctionApp Check'
-        if: steps.getFunctionList.outputs.FUNCTION_LIST == ''
+        if: steps.getFunctionList.outputs.FAIL == true
         run: |
           echo 'Azure FunctionApp Function is empty'
           exit 1  

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,7 +79,7 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST = *"ResourceNotFound"*]] \
+          if [[ $FUNCTION_LIST = *"ResourceNotFound"* ]] \
           then \ 
             FAIL=true \
           fi

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,9 +79,10 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST = *"ResourceNotFound"* ]] then
-            FAIL=true
-          fi
+          if [[ $FUNCTION_LIST = *"ResourceNotFound"* ]] \
+          then \
+            FAIL=true \
+          fi \
           echo "$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,7 +79,7 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST e *"ResourceNotFound"*]] \
+          if [[ $FUNCTION_LIST = *"ResourceNotFound"*]] \
           then \ 
             FAIL=true \
           fi

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,7 +79,7 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FAIL="false"
-          FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
+          FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}-2")
           if [[ $FUNCTION_LIST == *"ResourceNotFound"* ]]; then 
             FAIL="true" 
           fi 

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -78,4 +78,4 @@ jobs:
 
       - name: 'Validate that Azure FunctionApp loaded Functions'
         run: |
-          $(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}-2")
+          $(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,7 +79,7 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST == *"ResourceNotFound"*]] \
+          if [[ $FUNCTION_LIST e *"ResourceNotFound"*]] \
           then \ 
             FAIL=true \
           fi

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -84,7 +84,7 @@ jobs:
             FAIL="true" 
           fi 
           echo "$FAIL"
-          echo "$FAIL" >> $GITHUB_OUTPUT
+          echo "FAIL=$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 
       - name: 'Azure FunctionApp Check'


### PR DESCRIPTION
There are occasions where when deploying the Azure function that the Azure Function app function fails to start up.  We have added a command to list out the specific function app that will fail the pipeline step if the function didn't get created in Azure. 

## Issue

Add a link to the issue here.  Consider using
[Troubleshooting](https://github.com/CDCgov/trusted-intermediary/issues/1183)
