### PR TITLE
Set ingestion timer trigger to never run in staging

### DIFF
--- a/operations/environments/stg/main.tf
+++ b/operations/environments/stg/main.tf
@@ -30,5 +30,5 @@ module "template" {
 
   environment = "stg"
   deployer_id = "f5feabe7-5d37-40ba-94f2-e5c0760b4561" //github app registration in CDC Azure Entra
-  cron        = "0 30 9 * * 1-5"                       // Every weekday at 9:30 AM
+  cron        = "* * * 30 Feb *"                       //run every second of February 30th, which never happens and is the equivalent of never running
 }


### PR DESCRIPTION
## Description
Until the mu character ingestion issues are fixed, turn off auto ingestion in staging so that files won't have to be re-uploaded

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1467