### PR TITLE
Setup for 5xx Error Alerts

### DIFF
--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -43,3 +43,43 @@ resource "azurerm_monitor_metric_alert" "azure_4XX_alert" {
     ]
   }
 }
+
+resource "azurerm_monitor_metric_alert" "azure_5XX_alert" {
+  count               = local.non_pr_environment ? 1 : 0
+  name                = "cdc-rs-sftp-${var.environment}-azure-http-5XX-alert"
+  resource_group_name = data.azurerm_resource_group.group.name
+  scopes              = [azurerm_linux_web_app.sftp.id]
+  description         = "Action will be triggered when Http Status Code 5XX is greater than or equal to 1"
+  frequency           = "PT1M" // Checks every 1 minute
+  window_size         = "PT5M" // Every Check looks back 5 min for 5xx errors
+
+  criteria {
+    metric_namespace = "Microsoft.Web/sites"
+    metric_name      = "Http5xx"
+    aggregation      = "Total"
+    operator         = "GreaterThanOrEqual"
+    threshold        = 1
+  }
+
+  action {
+    action_group_id = data.azurerm_monitor_action_group.notify_slack_email[count.index].id
+  }
+
+  lifecycle {
+    # Ignore changes to tags because the CDC sets these automagically
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
+}

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -77,16 +77,6 @@ func setupLogging() {
 func setupHealthCheck() {
 	slog.Info("Bootstrapping health check")
 
-	http.HandleFunc("/test500", func(response http.ResponseWriter, request *http.Request) {
-		slog.Info("5xx ping", slog.String("method", request.Method), slog.String("path", request.URL.String()))
-
-		response.WriteHeader(500)
-		_, err := io.WriteString(response, "500 Peters are Great")
-		if err != nil {
-			slog.Error("Failed to respond to health check", slog.Any(utils.ErrorKey, err))
-		}
-	})
-
 	http.HandleFunc("/", func(response http.ResponseWriter, request *http.Request) {
 		slog.Info("Health check ping", slog.String("method", request.Method), slog.String("path", request.URL.String()))
 

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -77,6 +77,16 @@ func setupLogging() {
 func setupHealthCheck() {
 	slog.Info("Bootstrapping health check")
 
+	http.HandleFunc("/test500", func(response http.ResponseWriter, request *http.Request) {
+		slog.Info("5xx ping", slog.String("method", request.Method), slog.String("path", request.URL.String()))
+
+		response.WriteHeader(500)
+		_, err := io.WriteString(response, "500 Peters are Great")
+		if err != nil {
+			slog.Error("Failed to respond to health check", slog.Any(utils.ErrorKey, err))
+		}
+	})
+
 	http.HandleFunc("/", func(response http.ResponseWriter, request *http.Request) {
 		slog.Info("Health check ping", slog.String("method", request.Method), slog.String("path", request.URL.String()))
 


### PR DESCRIPTION
## Description

Added terraform for 5xx alerts for sftp ingestion service. Tested in internal triggering a 500 error to see Slack activation and deactivation alert.

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1394

## Checklist

**Note**: You may remove items that are not applicable
