### PR TITLE
Add CPU alert for ingestion service

### DIFF
--- a/operations/template/alert.tf
+++ b/operations/template/alert.tf
@@ -259,3 +259,44 @@ resource "azurerm_monitor_metric_alert" "rs_sftp_memory_alert" {
     ]
   }
 }
+
+resource "azurerm_monitor_metric_alert" "cpu_alert" {
+  count               = local.non_pr_environment ? 1 : 0
+  name                = "cdc-rs-sftp-${var.environment}-cpu-alert"
+  resource_group_name = data.azurerm_resource_group.group.name
+  scopes              = [azurerm_service_plan.plan.id]
+  description         = "Alerts when the average CPU usage across the service plan is high"
+  severity            = 2
+  frequency           = "PT1M"
+  window_size         = "PT15M"
+
+  criteria {
+    metric_name      = "CpuPercentage"
+    metric_namespace = "microsoft.web/serverfarms"
+    aggregation      = "Average"
+    operator         = "GreaterThan"
+    threshold        = 80 # We autoscale at 75%, so CPU over that means either we've hit the scaling limit or something is wrong with scaling
+  }
+
+  action {
+    action_group_id = data.azurerm_monitor_action_group.notify_slack_email[count.index].id
+  }
+
+  lifecycle {
+    # Ignore changes to tags because the CDC sets these automagically
+    ignore_changes = [
+      tags["business_steward"],
+      tags["center"],
+      tags["environment"],
+      tags["escid"],
+      tags["funding_source"],
+      tags["pii_data"],
+      tags["security_compliance"],
+      tags["security_steward"],
+      tags["support_group"],
+      tags["system"],
+      tags["technical_steward"],
+      tags["zone"]
+    ]
+  }
+}


### PR DESCRIPTION
## Description
Add Azure alerts when SFTP ingestion service app CPU usage is above 80% (we autoscale before that)

## Issue

https://github.com/CDCgov/trusted-intermediary/issues/1399
