### PR TITLE
Sleep in function app function check so we don't error prematurely

### DIFF
--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -78,21 +78,30 @@ jobs:
 
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
-          FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST == *"[]"* ]]; then
-            echo "::notice Azure FunctionApp Function is empty. Sleeping 15 seconds, then will check again"
-            sleep 15
-            FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
+          MAX_TIME=300   # Maximum time in seconds (5 minutes)
+          INTERVAL=5     # Check every 5 seconds
+          ELAPSED_TIME=0
+          FAIL=true
 
-            if [[ $FUNCTION_LIST == *"[]"* ]]; then
-              FAIL=true
+          # Loop until the function is created or the maximum time is reached
+          while [ $ELAPSED_TIME -lt $MAX_TIME ]; do
+            FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
+            if [[ $FUNCTION_LIST != *"[]"* ]]; then
+              echo "Function found after $ELAPSED_TIME seconds"
+              FAIL=false
+              break
             fi
-          fi
+            # If we don't have a function yet, sleep INTERVAL seconds and increment elapsed time
+            echo "Function not found, sleeping $INTERVAL seconds. $ELAPSED_TIME seconds have elapsed so far"
+            sleep $INTERVAL
+            ELAPSED_TIME=$((ELAPSED_TIME + INTERVAL))
+          done
+
           echo "FAIL=$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
 
       - name: 'Azure FunctionApp Failed'
         if: steps.getFunctionList.outputs.FAIL == 'true'
         run: |
-          echo "::notice Azure FunctionApp Function is empty"
+          echo 'Azure FunctionApp Function is empty'
           exit 1

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -79,7 +79,12 @@ jobs:
       - name: 'Retrieve Azure FunctionApp loaded Functions'
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          if [[ $FUNCTION_LIST == *"[]"* ]]; then 
+          if [[ $FUNCTION_LIST == *"[]"* ]]; then
+            echo 'Azure FunctionApp Function is empty. Sleeping 15 seconds, then will check again'
+            sleep 15
+            FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
+          fi
+          if [[ $FUNCTION_LIST == *"[]"* ]]; then
             FAIL=true
           fi
           echo "FAIL=$FAIL" >> $GITHUB_OUTPUT
@@ -89,4 +94,4 @@ jobs:
         if: steps.getFunctionList.outputs.FAIL == 'true'
         run: |
           echo 'Azure FunctionApp Function is empty'
-          exit 1 
+          exit 1

--- a/.github/workflows/functions-deploy.yml
+++ b/.github/workflows/functions-deploy.yml
@@ -80,12 +80,13 @@ jobs:
         run: |
           FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
           if [[ $FUNCTION_LIST == *"[]"* ]]; then
-            echo 'Azure FunctionApp Function is empty. Sleeping 15 seconds, then will check again'
+            echo "::notice Azure FunctionApp Function is empty. Sleeping 15 seconds, then will check again"
             sleep 15
             FUNCTION_LIST=$(az functionapp function list -g "csels-rsti-${{ inputs.TF_ENVIRONMENT }}-moderate-rg" -n "polling-function-${{ inputs.TF_ENVIRONMENT }}")
-          fi
-          if [[ $FUNCTION_LIST == *"[]"* ]]; then
-            FAIL=true
+
+            if [[ $FUNCTION_LIST == *"[]"* ]]; then
+              FAIL=true
+            fi
           fi
           echo "FAIL=$FAIL" >> $GITHUB_OUTPUT
         id: getFunctionList
@@ -93,5 +94,5 @@ jobs:
       - name: 'Azure FunctionApp Failed'
         if: steps.getFunctionList.outputs.FAIL == 'true'
         run: |
-          echo 'Azure FunctionApp Function is empty'
+          echo "::notice Azure FunctionApp Function is empty"
           exit 1

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -9,6 +9,7 @@ locals {
   higher_environment_level       = var.environment == "stg" || var.environment == "prd"
   cdc_domain_environment         = var.environment == "dev" || var.environment == "stg" || var.environment == "prd"
   non_pr_environment             = length(regexall("^pr\\d+", var.environment)) == 0
+  cheezburger                    = "cheezburger"
 }
 
 data "azurerm_resource_group" "group" {

--- a/operations/template/main.tf
+++ b/operations/template/main.tf
@@ -9,7 +9,6 @@ locals {
   higher_environment_level       = var.environment == "stg" || var.environment == "prd"
   cdc_domain_environment         = var.environment == "dev" || var.environment == "stg" || var.environment == "prd"
   non_pr_environment             = length(regexall("^pr\\d+", var.environment)) == 0
-  cheezburger                    = "cheezburger"
 }
 
 data "azurerm_resource_group" "group" {


### PR DESCRIPTION
## Description
Currently, after the function app function is deployed, we immediately check to see if it exists and error if it doesn't. Sometimes there's a lag between the function being successfully added to the function app and Azure returning it when we ask what functions are on the function app. I initially tried a plain 15 second sleep but that didn't work, so then we converted it to a loop that exits after either we find a function or 5 minutes have elapsed

You can see the updated script working here: https://github.com/CDCgov/reportstream-sftp-ingestion/actions/runs/11693396968/job/32564969417#:~:text=Function%20not%20found,33

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1556

