### PR TITLE
Zip file Retry

### DIFF
--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -238,7 +238,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 
 	slog.Info("About to consider whether this is a zip", slog.String(utils.FileNameKey, fileInfo.Name()))
 
-	deleteZipFolder := false
+	deleteZip := false
 	isZip := strings.Contains(fileInfo.Name(), ".zip")
 	if isZip {
 		// write file to local filesystem
@@ -252,7 +252,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		if err != nil {
 			slog.Error("Failed to unzip file", slog.Any(utils.ErrorKey, err))
 		} else {
-			deleteZipFolder = true
+			deleteZip = true
 		}
 
 		//delete file from local filesystem
@@ -262,7 +262,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		}
 	}
 
-	if !isZip || (isZip && deleteZipFolder) {
+	if !isZip || (isZip && deleteZip) {
 		err = receiver.sftpClient.Remove(fullFilePath)
 		if err != nil {
 			slog.Error("Failed to remove file from SFTP server", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -262,7 +262,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		}
 	}
 
-	if !isZip || (isZip && deleteZip) {
+	if !isZip || deleteZip {
 		err = receiver.sftpClient.Remove(fullFilePath)
 		if err != nil {
 			slog.Error("Failed to remove file from SFTP server", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -238,7 +238,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 
 	slog.Info("About to consider whether this is a zip", slog.String(utils.FileNameKey, fileInfo.Name()))
 
-	deleteZip := false
+	deleteZipFolder := false
 	isZip := strings.Contains(fileInfo.Name(), ".zip")
 	if isZip {
 		// write file to local filesystem
@@ -252,7 +252,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		if err != nil {
 			slog.Error("Failed to unzip file", slog.Any(utils.ErrorKey, err))
 		} else {
-			deleteZip = true
+			deleteZipFolder = true
 		}
 
 		//delete file from local filesystem
@@ -262,7 +262,7 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		}
 	}
 
-	if !isZip || (isZip && deleteZip) {
+	if !isZip || (isZip && deleteZipFolder) {
 		err = receiver.sftpClient.Remove(fullFilePath)
 		if err != nil {
 			slog.Error("Failed to remove file from SFTP server", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -270,5 +270,6 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 		}
 	}
 
+	//This logging statement needs refactoring for when the unzip fails
 	slog.Info("Successfully copied file and removed from SFTP server", slog.Any(utils.FileNameKey, fullFilePath))
 }

--- a/src/sftp/handler.go
+++ b/src/sftp/handler.go
@@ -268,8 +268,6 @@ func (receiver *SftpHandler) copySingleFile(fileInfo os.FileInfo, index int, dir
 			slog.Error("Failed to remove file from SFTP server", slog.Any(utils.ErrorKey, err), slog.String(utils.FileNameKey, fullFilePath))
 			return
 		}
+		slog.Info("Successfully copied file and removed from SFTP server", slog.Any(utils.FileNameKey, fullFilePath))
 	}
-
-	//This logging statement needs refactoring for when the unzip fails
-	slog.Info("Successfully copied file and removed from SFTP server", slog.Any(utils.FileNameKey, fullFilePath))
 }

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -439,9 +439,7 @@ func Test_copySingleFile_FailsToUnzipFile_LogsError(t *testing.T) {
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
 	mockSftpClient.AssertCalled(t, "Open", mock.Anything)
-	//mockSftpClient.AssertCalled(t, "Remove", mock.Anything)
 	assert.Contains(t, buffer.String(), "Failed to unzip file")
-	assert.Contains(t, buffer.String(), "Successfully copied file and removed from SFTP server")
 }
 
 func Test_copySingleFile_FailsToDeleteFileFromSFTPServer_LogsErrorAndReturn(t *testing.T) {

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -439,7 +439,9 @@ func Test_copySingleFile_FailsToUnzipFile_LogsError(t *testing.T) {
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
 	mockSftpClient.AssertCalled(t, "Open", mock.Anything)
+	mockSftpClient.AssertNotCalled(t, "Remove", mock.Anything)
 	assert.Contains(t, buffer.String(), "Failed to unzip file")
+
 }
 
 func Test_copySingleFile_FailsToDeleteFileFromSFTPServer_LogsErrorAndReturn(t *testing.T) {

--- a/src/sftp/handler_test.go
+++ b/src/sftp/handler_test.go
@@ -439,7 +439,7 @@ func Test_copySingleFile_FailsToUnzipFile_LogsError(t *testing.T) {
 
 	mockBlobHandler.AssertCalled(t, "UploadFile", mock.Anything, mock.Anything)
 	mockSftpClient.AssertCalled(t, "Open", mock.Anything)
-	mockSftpClient.AssertCalled(t, "Remove", mock.Anything)
+	//mockSftpClient.AssertCalled(t, "Remove", mock.Anything)
 	assert.Contains(t, buffer.String(), "Failed to unzip file")
 	assert.Contains(t, buffer.String(), "Successfully copied file and removed from SFTP server")
 }


### PR DESCRIPTION
## Description

- Failure to unzip files now no longer deletes the file from the SFTP Server
  - With this change, our cron will automagically retry unzipping. This will mean that a fix will need to be made in between the cron schedule to make unzipping work again.

## Issue

[#1558](https://github.com/CDCgov/trusted-intermediary/issues/1558)

## Checklist

- [x] I have added tests to cover my changes
- [x] I have added logging where useful (with appropriate log level)
