### PR TITLE
Add a new storage container for config

### DIFF
--- a/azure_functions/src/functions/caDphTimerTrigger.ts
+++ b/azure_functions/src/functions/caDphTimerTrigger.ts
@@ -13,7 +13,8 @@ export async function caDphTimerTrigger(myTimer: Timer, context: InvocationConte
     // We set the visibility timeout for the message on reading, in queue.go
     // messageTimeToLive of -1 means the message does not expire
     // the queue message contents will (in future) be the key to client-specific config
-    const sendMessageResponse = await queueClient.sendMessage("cadph", {messageTimeToLive: -1})
+    // The message we send here must match the key in config, the scope in report_stream_sender, and the org name in RS
+    const sendMessageResponse = await queueClient.sendMessage("ca-phl", {messageTimeToLive: -1})
     console.log("Sent message successfully, service assigned message Id:", sendMessageResponse.messageId, "service assigned request Id:", sendMessageResponse.requestId );
 
     context.log('Timer function processed request.');

--- a/config/local.json
+++ b/config/local.json
@@ -1,0 +1,8 @@
+{
+  "ca-phl": {
+    "shouldFetch": true
+  },
+  "flexion": {
+    "shouldFetch": true
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       - /bin/sh
       - -c
       - |
+        az storage container create -n config
         az storage container create -n sftp
         az storage blob upload --overwrite --account-name devstoreaccount1 --container-name sftp --name import/order_message.hl7 --file mock_data/order_message.hl7
         az storage queue create -n message-import-queue

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
         az storage container create -n config
         az storage container create -n sftp
         az storage blob upload --overwrite --account-name devstoreaccount1 --container-name sftp --name import/order_message.hl7 --file mock_data/order_message.hl7
+        az storage blob upload --overwrite --account-name devstoreaccount1 --container-name config --name config.json --file config/local.json
         az storage queue create -n message-import-queue
         az storage queue create -n message-import-dead-letter-queue
         az storage queue create -n polling-trigger-queue


### PR DESCRIPTION
## Description
- Add a new storage container for config and exempt it from the retention policy (config shouldn't be deleted, PHI should)
- Update the timer trigger function to send a message that matches the config label
- Create initial config for local

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1082

