### PR TITLE
remove platform from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       - ./mock_credentials:/home/myLowPrivilegeUser/mock_credentials
     ports:
       - "8081:8080" # default api endpoint port
-    platform: linux/amd64
     depends_on:
       sftp-Azurite:
         condition: service_started


### PR DESCRIPTION
# Description
The platform attribute in docker-compose doesn't work with Podman, and doesn't appear necessary with other platforms, so we're removing it

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1608