### PR TITLE
Add `containerId` Unique ID to Every Log Statement

### DIFF
--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -65,7 +65,7 @@ func setupLogging() {
 	environment := os.Getenv("ENV")
 
 	if environment == "" {
-		//environment = "local"
+		environment = "local"
 	}
 
 	if environment != "local" {

--- a/src/cmd/main.go
+++ b/src/cmd/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/CDCgov/reportstream-sftp-ingestion/orchestration"
 	"github.com/CDCgov/reportstream-sftp-ingestion/utils"
+	"github.com/google/uuid"
 	"io"
 	"log/slog"
 	"net/http"
@@ -64,7 +65,7 @@ func setupLogging() {
 	environment := os.Getenv("ENV")
 
 	if environment == "" {
-		environment = "local"
+		//environment = "local"
 	}
 
 	if environment != "local" {
@@ -72,6 +73,8 @@ func setupLogging() {
 		slog.SetDefault(logger)
 	}
 
+	// add a unique ID to the currently running container so we can identify logs uniquely in a better way than Azure's built-in _ResourceId and Host field
+	slog.SetDefault(slog.With(slog.String("containerId", uuid.NewString())))
 }
 
 func setupHealthCheck() {


### PR DESCRIPTION
## Description

@saquino0827 and I were triaging an error log statement in the live slot that we are missing the Azure connection string from the environment variable.  We only are missing that in the pre-live slot (which is on purpose).  We think this is due to Azure incorrectly attributing the log statement  to the live slot.

Therefore, @saquino0827 and I are improving the logging by adding a unique ID to the currently running container, so we can identify logs uniquely in a better way than Azure's built-in `_ResourceId` and `Host` field.

This should allow us to more easily track the life cycle of containers in which slot.

## Issue

_None_.

## Checklist

- [x] I have added logging where useful (with appropriate log level)
