### PR TITLE
split out live and pre-live queries

### DIFF
--- a/operations/template/logs.tf
+++ b/operations/template/logs.tf
@@ -25,14 +25,24 @@ resource "azurerm_log_analytics_query_pack" "application_logs_pack" {
   }
 }
 
-resource "azurerm_log_analytics_query_pack_query" "structured_application_logs" {
-  display_name = "RS SFTP's Raw Application Logs"
-  description  = "View all RS SFTP's application logs in a structured format"
+resource "azurerm_log_analytics_query_pack_query" "live_structured_application_logs" {
+  display_name = "RS SFTP's Live Slot Raw Application Logs"
+  description  = "View RS SFTP's live slot application logs in a structured format"
 
   query_pack_id = azurerm_log_analytics_query_pack.application_logs_pack.id
   categories    = ["applications"]
 
-  body = "AppServiceConsoleLogs | project JsonResult = parse_json(ResultDescription) | evaluate bag_unpack(JsonResult) | project-reorder ['time'], level, msg"
+  body = "AppServiceConsoleLogs | where _ResourceId !contains 'pre-live' | project JsonResult = parse_json(ResultDescription) | evaluate bag_unpack(JsonResult) | project-reorder ['time'], level, msg"
+}
+
+resource "azurerm_log_analytics_query_pack_query" "prelive_structured_application_logs" {
+  display_name = "RS SFTP's Pre-Live Slot Raw Application Logs"
+  description  = "View RS SFTP's pre-live slot application logs in a structured format"
+
+  query_pack_id = azurerm_log_analytics_query_pack.application_logs_pack.id
+  categories    = ["applications"]
+
+  body = "AppServiceConsoleLogs | where _ResourceId contains 'pre-live' | project JsonResult = parse_json(ResultDescription) | evaluate bag_unpack(JsonResult) | project-reorder ['time'], level, msg"
 }
 
 resource "azurerm_monitor_diagnostic_setting" "app_to_logs" {


### PR DESCRIPTION
## Description
Split the query pack query into two separate ones for the live and pre-live slots

## Issue
https://github.com/CDCgov/trusted-intermediary/issues/1657
